### PR TITLE
feat: support element

### DIFF
--- a/packages/contracts/test/sdk/element/contract-wide/erc1155.test.ts
+++ b/packages/contracts/test/sdk/element/contract-wide/erc1155.test.ts
@@ -1,0 +1,115 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+
+describe("Element - ContractWide Erc1155", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+
+  let erc1155: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob, carol] = await ethers.getSigners();
+
+    ({ erc1155 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.ContractWide(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc1155.address,
+      amount: 1,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc1155
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({
+      amount: 1,
+      tokenId: boughtTokenId,
+    });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerWethBalanceBefore = await weth.getBalance(buyer.address);
+    const buyerNftBalanceBefore = await nft.getBalance(
+      buyer.address,
+      boughtTokenId
+    );
+    const sellerNftBalanceBefore = await nft.getBalance(
+      seller.address,
+      boughtTokenId
+    );
+
+    expect(buyerWethBalanceBefore).to.eq(price);
+    expect(buyerNftBalanceBefore).to.eq(0);
+    expect(sellerNftBalanceBefore).to.eq(1);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerWethBalanceAfter = await weth.getBalance(buyer.address);
+    const buyerNftBalanceAfter = await nft.getBalance(
+      buyer.address,
+      boughtTokenId
+    );
+    const sellerNftBalanceAfter = await nft.getBalance(
+      seller.address,
+      boughtTokenId
+    );
+
+    expect(buyerWethBalanceAfter).to.eq(0);
+    expect(buyerNftBalanceAfter).to.eq(1);
+    expect(sellerNftBalanceAfter).to.eq(0);
+  });
+});

--- a/packages/contracts/test/sdk/element/contract-wide/erc721.test.ts
+++ b/packages/contracts/test/sdk/element/contract-wide/erc721.test.ts
@@ -1,0 +1,94 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+
+describe("Element - ContractWide Erc721", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+
+  let erc721: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob, carol] = await ethers.getSigners();
+
+    ({ erc721 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.ContractWide(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ tokenId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await weth.getBalance(buyer.address);
+    const ownerBefore = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceBefore).to.eq(price);
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerBalanceAfter = await weth.getBalance(buyer.address);
+    const ownerAfter = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceAfter).to.eq(0);
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+});

--- a/packages/contracts/test/sdk/element/single-token/erc1155.test.ts
+++ b/packages/contracts/test/sdk/element/single-token/erc1155.test.ts
@@ -1,0 +1,599 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+
+describe("Element - SingleToken Erc1155", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let ted: SignerWithAddress;
+
+  let erc1155: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob, carol, ted] = await ethers.getSigners();
+
+    ({ erc1155 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 0;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc1155.address,
+      tokenId: boughtTokenId,
+      amount: 1,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+
+    // Approve the exchange for escrowing.
+    await erc1155
+    .connect(seller)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ amount: 1 });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerWethBalanceBefore = await weth.getBalance(buyer.address);
+    const buyerNftBalanceBefore = await nft.getBalance(
+      buyer.address,
+      boughtTokenId
+    );
+    const sellerNftBalanceBefore = await nft.getBalance(
+      seller.address,
+      boughtTokenId
+    );
+
+    expect(buyerWethBalanceBefore).to.eq(price);
+    expect(buyerNftBalanceBefore).to.eq(0);
+    expect(sellerNftBalanceBefore).to.eq(1);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerWethBalanceAfter = await weth.getBalance(buyer.address);
+    const buyerNftBalanceAfter = await nft.getBalance(
+      buyer.address,
+      boughtTokenId
+    );
+    const sellerNftBalanceAfter = await nft.getBalance(
+      seller.address,
+      boughtTokenId
+    );
+
+    expect(buyerWethBalanceAfter).to.eq(0);
+    expect(buyerNftBalanceAfter).to.eq(1);
+    expect(sellerNftBalanceAfter).to.eq(0);
+  });
+
+  it("Build and fill buy order with partial fill and fees", async () => {
+    const buyer = alice;
+    const seller1 = bob;
+    const seller2 = carol;
+    const price = parseEther("1.8");
+    const boughtTokenId = 0;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price.add(parseEther("0.3")));
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller1).mint(boughtTokenId);
+    await erc1155.connect(seller1).mint(boughtTokenId);
+    await erc1155.connect(seller2).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc1155.address,
+      tokenId: boughtTokenId,
+      amount: 3,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      fees: [
+        {
+          recipient: ted.address,
+          amount: parseEther("0.3"),
+        },
+      ],
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc1155
+    .connect(seller1)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+    
+    await erc1155
+    .connect(seller2)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    // First fill
+    {
+      const seller = seller1;
+
+      // Create matching sell order
+      const sellOrder = buyOrder.buildMatching({ amount: 2 });
+
+      const buyerNftBalanceBefore = await nft.getBalance(
+        buyer.address,
+        boughtTokenId
+      );
+      const sellerNftBalanceBefore = await nft.getBalance(
+        seller.address,
+        boughtTokenId
+      );
+
+      expect(buyerNftBalanceBefore).to.eq(0);
+      expect(sellerNftBalanceBefore).to.eq(2);
+
+      // Match orders
+      await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+      const buyerWethBalanceAfter = await weth.getBalance(buyer.address);
+      const tedWethBalanceAfter = await weth.getBalance(ted.address);
+      const buyerNftBalanceAfter = await nft.getBalance(
+        buyer.address,
+        boughtTokenId
+      );
+      const sellerNftBalanceAfter = await nft.getBalance(
+        seller.address,
+        boughtTokenId
+      );
+
+      expect(buyerWethBalanceAfter).to.eq(
+        price.add(
+          parseEther("0.3")
+            .sub(price.mul(2).div(3))
+            .sub(parseEther("0.3").mul(2).div(3))
+        )
+      );
+      expect(tedWethBalanceAfter).to.eq(parseEther("0.3").mul(2).div(3));
+      expect(buyerNftBalanceAfter).to.eq(2);
+      expect(sellerNftBalanceAfter).to.eq(0);
+    }
+
+    // Second fill
+    {
+      const seller = seller2;
+
+      // Create matching sell order
+      const sellOrder = buyOrder.buildMatching({ amount: 1 });
+
+      const buyerNftBalanceBefore = await nft.getBalance(
+        buyer.address,
+        boughtTokenId
+      );
+      const sellerNftBalanceBefore = await nft.getBalance(
+        seller.address,
+        boughtTokenId
+      );
+
+      expect(buyerNftBalanceBefore).to.eq(2);
+      expect(sellerNftBalanceBefore).to.eq(1);
+
+      // Match orders
+      await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+      const buyerWethBalanceAfter = await weth.getBalance(buyer.address);
+      const tedWethBalanceAfter = await weth.getBalance(ted.address);
+      const buyerNftBalanceAfter = await nft.getBalance(
+        buyer.address,
+        boughtTokenId
+      );
+      const sellerNftBalanceAfter = await nft.getBalance(
+        seller.address,
+        boughtTokenId
+      );
+
+      expect(buyerWethBalanceAfter).to.eq(0);
+      expect(tedWethBalanceAfter).to.eq(parseEther("0.3"));
+      expect(buyerNftBalanceAfter).to.eq(3);
+      expect(sellerNftBalanceAfter).to.eq(0);
+    }
+  });
+
+  it("Build and fill sell order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const soldTokenId = 0;
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller).mint(soldTokenId);
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    // Approve the exchange
+    await nft.approve(seller, Element.Addresses.Exchange[chainId]);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build sell order
+    const sellOrder = builder.build({
+      direction: "sell",
+      maker: seller.address,
+      contract: erc1155.address,
+      tokenId: soldTokenId,
+      amount: 1,
+      paymentToken: Element.Addresses.Eth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await sellOrder.sign(seller, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc1155
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching buy order
+    const buyOrder = sellOrder.buildMatching({ amount: 1 });
+
+    await sellOrder.checkFillability(ethers.provider);
+
+    const buyerEthBalanceBefore = await ethers.provider.getBalance(
+      buyer.address
+    );
+    const sellerEthBalanceBefore = await ethers.provider.getBalance(
+      seller.address
+    );
+    const buyerNftBalanceBefore = await nft.getBalance(
+      buyer.address,
+      soldTokenId
+    );
+    const sellerNftBalanceBefore = await nft.getBalance(
+      seller.address,
+      soldTokenId
+    );
+
+    expect(buyerNftBalanceBefore).to.eq(0);
+    expect(sellerNftBalanceBefore).to.eq(1);
+
+    // Match orders
+    await exchange.fillOrder(buyer, sellOrder, buyOrder);
+
+    const buyerEthBalanceAfter = await ethers.provider.getBalance(
+      buyer.address
+    );
+    const sellerEthBalanceAfter = await ethers.provider.getBalance(
+      seller.address
+    );
+    const buyerNftBalanceAfter = await nft.getBalance(
+      buyer.address,
+      soldTokenId
+    );
+    const sellerNftBalanceAfter = await nft.getBalance(
+      seller.address,
+      soldTokenId
+    );
+
+    expect(buyerEthBalanceBefore.sub(buyerEthBalanceAfter)).to.be.gt(price);
+    expect(sellerEthBalanceAfter).to.eq(sellerEthBalanceBefore.add(price));
+    expect(buyerNftBalanceAfter).to.eq(1);
+    expect(sellerNftBalanceAfter).to.eq(0);
+  });
+
+  it("Build and fill sell order with partial fill", async () => {
+    const buyer1 = alice;
+    const buyer2 = carol;
+    const seller = bob;
+    const price = parseEther("1");
+    const soldTokenId = 0;
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller).mint(soldTokenId);
+    await erc1155.connect(seller).mint(soldTokenId);
+    await erc1155.connect(seller).mint(soldTokenId);
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    // Approve the exchange
+    await nft.approve(seller, Element.Addresses.Exchange[chainId]);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build sell order
+    const sellOrder = builder.build({
+      direction: "sell",
+      maker: seller.address,
+      contract: erc1155.address,
+      tokenId: soldTokenId,
+      amount: 3,
+      paymentToken: Element.Addresses.Eth[chainId],
+      price,
+      fees: [
+        {
+          recipient: ted.address,
+          amount: parseEther("0.3"),
+        },
+      ],
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await sellOrder.sign(seller, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc1155
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    await sellOrder.checkFillability(ethers.provider);
+
+    // First fill
+    {
+      const buyer = buyer1;
+
+      // Create matching buy order
+      const buyOrder = sellOrder.buildMatching({ amount: 2 });
+
+      const buyerEthBalanceBefore = await ethers.provider.getBalance(
+        buyer.address
+      );
+      const sellerEthBalanceBefore = await ethers.provider.getBalance(
+        seller.address
+      );
+      const tedEthBalanceBefore = await ethers.provider.getBalance(ted.address);
+      const buyerNftBalanceBefore = await nft.getBalance(
+        buyer.address,
+        soldTokenId
+      );
+      const sellerNftBalanceBefore = await nft.getBalance(
+        seller.address,
+        soldTokenId
+      );
+
+      expect(buyerNftBalanceBefore).to.eq(0);
+      expect(sellerNftBalanceBefore).to.eq(3);
+
+      // Match orders
+      await exchange.fillOrder(buyer, sellOrder, buyOrder);
+
+      const buyerEthBalanceAfter = await ethers.provider.getBalance(
+        buyer.address
+      );
+      const sellerEthBalanceAfter = await ethers.provider.getBalance(
+        seller.address
+      );
+      const tedEthBalanceAfter = await ethers.provider.getBalance(ted.address);
+      const buyerNftBalanceAfter = await nft.getBalance(
+        buyer.address,
+        soldTokenId
+      );
+      const sellerNftBalanceAfter = await nft.getBalance(
+        seller.address,
+        soldTokenId
+      );
+
+      expect(buyerEthBalanceBefore.sub(buyerEthBalanceAfter)).to.be.gt(
+        price.mul(2).div(3)
+      );
+      expect(sellerEthBalanceAfter).to.be.gte(
+        sellerEthBalanceBefore.add(price.mul(2).div(3))
+      );
+      expect(tedEthBalanceAfter.sub(tedEthBalanceBefore)).to.eq(
+        parseEther("0.3").mul(2).div(3)
+      );
+      expect(buyerNftBalanceAfter).to.eq(2);
+      expect(sellerNftBalanceAfter).to.eq(1);
+    }
+
+    // Second fill
+    {
+      const buyer = buyer2;
+
+      // Create matching buy order
+      const buyOrder = sellOrder.buildMatching({ amount: 1 });
+
+      const buyerEthBalanceBefore = await ethers.provider.getBalance(
+        buyer.address
+      );
+      const sellerEthBalanceBefore = await ethers.provider.getBalance(
+        seller.address
+      );
+      const tedEthBalanceBefore = await ethers.provider.getBalance(ted.address);
+      const buyerNftBalanceBefore = await nft.getBalance(
+        buyer.address,
+        soldTokenId
+      );
+      const sellerNftBalanceBefore = await nft.getBalance(
+        seller.address,
+        soldTokenId
+      );
+
+      expect(buyerNftBalanceBefore).to.eq(0);
+      expect(sellerNftBalanceBefore).to.eq(1);
+
+      // Match orders
+      await exchange.fillOrder(buyer, sellOrder, buyOrder);
+
+      const buyerEthBalanceAfter = await ethers.provider.getBalance(
+        buyer.address
+      );
+      const sellerEthBalanceAfter = await ethers.provider.getBalance(
+        seller.address
+      );
+      const tedEthBalanceAfter = await ethers.provider.getBalance(ted.address);
+      const buyerNftBalanceAfter = await nft.getBalance(
+        buyer.address,
+        soldTokenId
+      );
+      const sellerNftBalanceAfter = await nft.getBalance(
+        seller.address,
+        soldTokenId
+      );
+
+      expect(buyerEthBalanceBefore.sub(buyerEthBalanceAfter)).to.be.gt(
+        price.mul(1).div(3)
+      );
+      expect(sellerEthBalanceAfter).to.be.gte(
+        sellerEthBalanceBefore.add(price.mul(1).div(3))
+      );
+      expect(tedEthBalanceAfter.sub(tedEthBalanceBefore)).to.eq(
+        parseEther("0.1")
+      );
+      expect(buyerNftBalanceAfter).to.eq(1);
+      expect(sellerNftBalanceAfter).to.eq(0);
+    }
+  });
+
+  it("Batch buy", async () => {
+    const buyer = alice;
+    const soldTokenId = 0;
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    const sellOrders: Element.Order[] = [];
+    for (const seller of [bob, carol]) {
+      // Mint erc1155 to seller
+      await erc1155.connect(seller).mint(soldTokenId);
+      await erc1155.connect(seller).mint(soldTokenId);
+
+      // Approve the exchange
+      await nft.approve(seller, Element.Addresses.Exchange[chainId]);
+
+      const builder = new Element.Builders.SingleToken(chainId);
+
+      // Build sell order
+      const sellOrder = builder.build({
+        direction: "sell",
+        maker: seller.address,
+        contract: erc1155.address,
+        tokenId: soldTokenId,
+        amount: 2,
+        paymentToken: Element.Addresses.Eth[chainId],
+        price: parseEther("0.5"),
+        fees: [
+          {
+            recipient: ted.address,
+            amount: parseEther("0.07"),
+          },
+        ],
+        expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      });
+
+      // Sign the order
+      await sellOrder.sign(seller, ethers.provider);
+
+      // Approve the exchange for escrowing.
+      await erc1155
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+      await sellOrder.checkFillability(ethers.provider);
+
+      sellOrders.push(sellOrder);
+    }
+
+    const matchParams: Element.Types.MatchParams[] = [];
+    for (const sellOrder of sellOrders) {
+      // Create matching buy order
+      const buyOrder = sellOrder.buildMatching({ amount: 1 });
+
+      matchParams.push(buyOrder);
+    }
+
+    const buyerNftBalanceBefore = await nft.getBalance(
+      buyer.address,
+      soldTokenId
+    );
+    const bobNftBalanceBefore = await nft.getBalance(bob.address, soldTokenId);
+    const carolNftBalanceBefore = await nft.getBalance(
+      carol.address,
+      soldTokenId
+    );
+
+    expect(buyerNftBalanceBefore).to.eq(0);
+    expect(bobNftBalanceBefore).to.eq(2);
+    expect(carolNftBalanceBefore).to.eq(2);
+
+    const exchange = new Element.Exchange(chainId);
+
+    // Match orders
+    await exchange.batchBuy(buyer, sellOrders, matchParams);
+
+    const buyerNftBalanceAfter = await nft.getBalance(
+      buyer.address,
+      soldTokenId
+    );
+    const bobNftBalanceAfter = await nft.getBalance(bob.address, soldTokenId);
+    const carolNftBalanceAfter = await nft.getBalance(
+      carol.address,
+      soldTokenId
+    );
+
+    expect(buyerNftBalanceAfter).to.eq(2);
+    expect(bobNftBalanceAfter).to.eq(1);
+    expect(carolNftBalanceAfter).to.eq(1);
+  });
+});

--- a/packages/contracts/test/sdk/element/single-token/erc721.test.ts
+++ b/packages/contracts/test/sdk/element/single-token/erc721.test.ts
@@ -1,0 +1,319 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+
+describe("Element - SingleToken Erc721", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let ted: SignerWithAddress;
+
+  let erc721: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob, carol, ted] = await ethers.getSigners();
+
+    ({ erc721 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 0;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      tokenId: boughtTokenId,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 10000,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+    .connect(seller)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching();
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await weth.getBalance(buyer.address);
+
+    const ownerBefore = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceBefore).to.eq(price);
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerBalanceAfter = await weth.getBalance(buyer.address);
+    const ownerAfter = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceAfter).to.eq(0);
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+
+  it("Build and fill sell order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const soldTokenId = 0;
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(soldTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    // Approve the exchange
+    await nft.approve(seller, Element.Addresses.Exchange[chainId]);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build sell order
+    const sellOrder = builder.build({
+      direction: "sell",
+      maker: seller.address,
+      contract: erc721.address,
+      tokenId: soldTokenId,
+      paymentToken: Element.Addresses.Eth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 100,
+    });
+
+    // Sign the order
+    await sellOrder.sign(seller, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+    .connect(seller)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching buy order
+    const buyOrder = sellOrder.buildMatching();
+
+    await sellOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await ethers.provider.getBalance(buyer.address);
+    const sellerBalanceBefore = await ethers.provider.getBalance(
+      seller.address
+    );
+    const ownerBefore = await nft.getOwner(soldTokenId);
+
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(buyer, sellOrder, buyOrder);
+
+    const buyerBalanceAfter = await ethers.provider.getBalance(buyer.address);
+    const sellerBalanceAfter = await ethers.provider.getBalance(seller.address);
+    const ownerAfter = await nft.getOwner(soldTokenId);
+
+    expect(buyerBalanceBefore.sub(buyerBalanceAfter)).to.be.gt(price);
+    expect(sellerBalanceAfter).to.eq(sellerBalanceBefore.add(price));
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+
+  it("Build and fill buy order with fees", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 0;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price.add(parseEther("0.15")));
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      tokenId: boughtTokenId,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      fees: [
+        {
+          recipient: carol.address,
+          amount: parseEther("0.1"),
+        },
+        {
+          recipient: ted.address,
+          amount: parseEther("0.05"),
+        },
+      ],
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+    .connect(seller)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching();
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await weth.getBalance(buyer.address);
+    const ownerBefore = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceBefore).to.eq(price.add(parseEther("0.15")));
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerBalanceAfter = await weth.getBalance(buyer.address);
+    const carolBalanceAfter = await weth.getBalance(carol.address);
+    const tedBalanceAfter = await weth.getBalance(ted.address);
+    const ownerAfter = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceAfter).to.eq(0);
+    expect(carolBalanceAfter).to.eq(parseEther("0.1"));
+    expect(tedBalanceAfter).to.eq(parseEther("0.05"));
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+
+  it("Build and fill sell order with fees", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const soldTokenId = 0;
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(soldTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    // Approve the exchange
+    await nft.approve(seller, Element.Addresses.Exchange[chainId]);
+
+    const exchange = new Element.Exchange(chainId);
+
+    const builder = new Element.Builders.SingleToken(chainId);
+
+    // Build sell order
+    const sellOrder = builder.build({
+      direction: "sell",
+      maker: seller.address,
+      contract: erc721.address,
+      tokenId: soldTokenId,
+      paymentToken: Element.Addresses.Eth[chainId],
+      price,
+      fees: [
+        {
+          recipient: carol.address,
+          amount: parseEther("0.1"),
+        },
+        {
+          recipient: ted.address,
+          amount: parseEther("0.05"),
+        },
+      ],
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+
+    // Sign the order
+    await sellOrder.sign(seller, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+    .connect(seller)
+    .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching buy order
+    const buyOrder = sellOrder.buildMatching();
+
+    await sellOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await ethers.provider.getBalance(buyer.address);
+    const sellerBalanceBefore = await ethers.provider.getBalance(
+      seller.address
+    );
+    const carolBalanceBefore = await ethers.provider.getBalance(carol.address);
+    const tedBalanceBefore = await ethers.provider.getBalance(ted.address);
+    const ownerBefore = await nft.getOwner(soldTokenId);
+
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(buyer, sellOrder, buyOrder, {
+      referrer: "reservoir.market",
+    });
+
+    const buyerBalanceAfter = await ethers.provider.getBalance(buyer.address);
+    const sellerBalanceAfter = await ethers.provider.getBalance(seller.address);
+    const carolBalanceAfter = await ethers.provider.getBalance(carol.address);
+    const tedBalanceAfter = await ethers.provider.getBalance(ted.address);
+    const ownerAfter = await nft.getOwner(soldTokenId);
+
+    expect(buyerBalanceBefore.sub(buyerBalanceAfter)).to.be.gt(
+      price.add(parseEther("0.15"))
+    );
+    expect(carolBalanceAfter.sub(carolBalanceBefore)).to.eq(parseEther("0.1"));
+    expect(tedBalanceAfter.sub(tedBalanceBefore)).to.eq(parseEther("0.05"));
+    expect(sellerBalanceAfter).to.eq(sellerBalanceBefore.add(price));
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+});

--- a/packages/contracts/test/sdk/element/token-list/bit-vector/erc721.test.ts
+++ b/packages/contracts/test/sdk/element/token-list/bit-vector/erc721.test.ts
@@ -1,0 +1,143 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../../utils";
+
+describe("Element - BitVector TokenList Erc721", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+
+  let erc721: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob] = await ethers.getSigners();
+
+    ({ erc721 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 827;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenList.BitVector(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      tokenIds: [0, 1, 2, 100, 101, 102, 675, 373, 748, 253, 827, 576],
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ tokenId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await weth.getBalance(buyer.address);
+    const ownerBefore = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceBefore).to.eq(price);
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerBalanceAfter = await weth.getBalance(buyer.address);
+    const ownerAfter = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceAfter).to.eq(0);
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+
+  it("Fails to fill buy order if token id is not in list", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 103;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenList.BitVector(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      tokenIds: [0, 2, 100, 101, 102],
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ nftId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    // Match orders
+    await expect(exchange.fillOrder(seller, buyOrder, sellOrder)).to.be
+      .reverted;
+  });
+});

--- a/packages/contracts/test/sdk/element/token-list/packed-list/erc721.test.ts
+++ b/packages/contracts/test/sdk/element/token-list/packed-list/erc721.test.ts
@@ -1,0 +1,143 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../../utils";
+
+describe("Element - PackedList TokenList Erc721", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+
+  let erc721: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob] = await ethers.getSigners();
+
+    ({ erc721 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenList.PackedList(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      tokenIds: [0, 1, 2, 100, 101, 102, 675, 373, 748, 253, 827, 576],
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ tokenId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await weth.getBalance(buyer.address);
+    const ownerBefore = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceBefore).to.eq(price);
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerBalanceAfter = await weth.getBalance(buyer.address);
+    const ownerAfter = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceAfter).to.eq(0);
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+
+  it("Fails to fill buy order if token id is not in list", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 103;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenList.PackedList(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      tokenIds: [0, 2, 100, 101, 102],
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ nftId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    // Match orders
+    await expect(exchange.fillOrder(seller, buyOrder, sellOrder)).to.be
+      .reverted;
+  });
+});

--- a/packages/contracts/test/sdk/element/token-range/erc1155.test.ts
+++ b/packages/contracts/test/sdk/element/token-range/erc1155.test.ts
@@ -1,0 +1,169 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+
+describe("Element - TokenRange Erc1155", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+
+  let erc1155: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob] = await ethers.getSigners();
+
+    ({ erc1155 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc1155(ethers.provider, erc1155.address);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenRange(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc1155.address,
+      amount: 1,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      startTokenId: 0,
+      endTokenId: 2,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc1155
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({
+      amount: 1,
+      tokenId: boughtTokenId,
+    });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerWethBalanceBefore = await weth.getBalance(buyer.address);
+    const buyerNftBalanceBefore = await nft.getBalance(
+      buyer.address,
+      boughtTokenId
+    );
+    const sellerNftBalanceBefore = await nft.getBalance(
+      seller.address,
+      boughtTokenId
+    );
+
+    expect(buyerWethBalanceBefore).to.eq(price);
+    expect(buyerNftBalanceBefore).to.eq(0);
+    expect(sellerNftBalanceBefore).to.eq(1);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerWethBalanceAfter = await weth.getBalance(buyer.address);
+    const buyerNftBalanceAfter = await nft.getBalance(
+      buyer.address,
+      boughtTokenId
+    );
+    const sellerNftBalanceAfter = await nft.getBalance(
+      seller.address,
+      boughtTokenId
+    );
+
+    expect(buyerWethBalanceAfter).to.eq(0);
+    expect(buyerNftBalanceAfter).to.eq(1);
+    expect(sellerNftBalanceAfter).to.eq(0);
+  });
+
+  it("Fails to fill buy order if token id out of range", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc1155 to seller
+    await erc1155.connect(seller).mint(boughtTokenId);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenRange(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc1155.address,
+      amount: 1,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      startTokenId: 2,
+      endTokenId: 3,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc1155
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({
+      amount: 1,
+      nftId: boughtTokenId,
+    });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    // Match orders
+    await expect(exchange.fillOrder(seller, buyOrder, sellOrder)).to.be
+      .reverted;
+  });
+});

--- a/packages/contracts/test/sdk/element/token-range/erc721.test.ts
+++ b/packages/contracts/test/sdk/element/token-range/erc721.test.ts
@@ -1,0 +1,145 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Common from "@reservoir0x/sdk/src/common";
+import * as Element from "@reservoir0x/sdk/src/element";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getChainId,
+  getCurrentTimestamp,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+
+describe("Element - TokenRange Erc721", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+
+  let erc721: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob] = await ethers.getSigners();
+
+    ({ erc721 } = await setupNFTs(deployer));
+  });
+
+  afterEach(reset);
+
+  it("Build and fill buy order", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const nft = new Common.Helpers.Erc721(ethers.provider, erc721.address);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenRange(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      startTokenId: 0,
+      endTokenId: 2,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ tokenId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    const buyerBalanceBefore = await weth.getBalance(buyer.address);
+    const ownerBefore = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceBefore).to.eq(price);
+    expect(ownerBefore).to.eq(seller.address);
+
+    // Match orders
+    await exchange.fillOrder(seller, buyOrder, sellOrder);
+
+    const buyerBalanceAfter = await weth.getBalance(buyer.address);
+    const ownerAfter = await nft.getOwner(boughtTokenId);
+
+    expect(buyerBalanceAfter).to.eq(0);
+    expect(ownerAfter).to.eq(buyer.address);
+  });
+
+  it("Fails to fill buy order if token id out of range", async () => {
+    const buyer = alice;
+    const seller = bob;
+    const price = parseEther("1");
+    const boughtTokenId = 1;
+
+    const weth = new Common.Helpers.Weth(ethers.provider, chainId);
+
+    // Mint weth to buyer
+    await weth.deposit(buyer, price);
+
+    // Approve the exchange contract for the buyer
+    await weth.approve(buyer, Element.Addresses.Exchange[chainId]);
+
+    // Mint erc721 to seller
+    await erc721.connect(seller).mint(boughtTokenId);
+
+    const exchange = new Element.Exchange(chainId);
+    const builder = new Element.Builders.TokenRange(chainId);
+
+    // Build buy order
+    const buyOrder = builder.build({
+      direction: "buy",
+      maker: buyer.address,
+      contract: erc721.address,
+      paymentToken: Common.Addresses.Weth[chainId],
+      price,
+      expiry: (await getCurrentTimestamp(ethers.provider)) + 60,
+      startTokenId: 2,
+      endTokenId: 3,
+    });
+
+    // Sign the order
+    await buyOrder.sign(buyer, ethers.provider);
+
+    // Approve the exchange for escrowing.
+    await erc721
+      .connect(seller)
+      .setApprovalForAll(Element.Addresses.Exchange[chainId], true);
+
+    // Create matching sell order
+    const sellOrder = buyOrder.buildMatching({ nftId: boughtTokenId });
+
+    await buyOrder.checkFillability(ethers.provider);
+
+    // Match orders
+    await expect(exchange.fillOrder(seller, buyOrder, sellOrder)).to.be
+      .reverted;
+  });
+});

--- a/packages/sdk/src/element/abis/Exchange.json
+++ b/packages/sdk/src/element/abis/Exchange.json
@@ -1,0 +1,5007 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc1155Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "erc1155FillAmount",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ERC1155BuyOrderFilled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20",
+                "name": "erc20Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20TokenAmount",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "feeData",
+                        "type": "bytes"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct LibNFTOrder.Fee[]",
+                "name": "fees",
+                "type": "tuple[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc1155Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc1155TokenId",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IPropertyValidator",
+                        "name": "propertyValidator",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "propertyData",
+                        "type": "bytes"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct LibNFTOrder.Property[]",
+                "name": "erc1155TokenProperties",
+                "type": "tuple[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "erc1155TokenAmount",
+                "type": "uint128"
+            }
+        ],
+        "name": "ERC1155BuyOrderPreSigned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "ERC1155OrderCancelled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc1155Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "erc1155FillAmount",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ERC1155SellOrderFilled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20",
+                "name": "erc20Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20TokenAmount",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "feeData",
+                        "type": "bytes"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct LibNFTOrder.Fee[]",
+                "name": "fees",
+                "type": "tuple[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc1155Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc1155TokenId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "erc1155TokenAmount",
+                "type": "uint128"
+            }
+        ],
+        "name": "ERC1155SellOrderPreSigned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc721Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ERC721BuyOrderFilled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20",
+                "name": "erc20Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20TokenAmount",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "feeData",
+                        "type": "bytes"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct LibNFTOrder.Fee[]",
+                "name": "fees",
+                "type": "tuple[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc721Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc721TokenId",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IPropertyValidator",
+                        "name": "propertyValidator",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "propertyData",
+                        "type": "bytes"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct LibNFTOrder.Property[]",
+                "name": "nftProperties",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "ERC721BuyOrderPreSigned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "ERC721OrderCancelled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc721Token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ERC721SellOrderFilled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "expiry",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20",
+                "name": "erc20Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc20TokenAmount",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "feeData",
+                        "type": "bytes"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct LibNFTOrder.Fee[]",
+                "name": "fees",
+                "type": "tuple[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc721Token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "erc721TokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "ERC721SellOrderPreSigned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newHashNonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "HashNonceIncremented",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "caller",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "migrator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "Migrated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "oldImpl",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newImpl",
+                "type": "address"
+            }
+        ],
+        "name": "ProxyFunctionUpdated",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder[]",
+                "name": "sellOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "signatures",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "uint128[]",
+                "name": "erc1155TokenAmounts",
+                "type": "uint128[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "revertIfIncomplete",
+                "type": "bool"
+            }
+        ],
+        "name": "batchBuyERC1155s",
+        "outputs": [
+            {
+                "internalType": "bool[]",
+                "name": "successes",
+                "type": "bool[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder[]",
+                "name": "sellOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "signatures",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "takers",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint128[]",
+                "name": "erc1155TokenAmounts",
+                "type": "uint128[]"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "callbackData",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "revertIfIncomplete",
+                "type": "bool"
+            }
+        ],
+        "name": "batchBuyERC1155sEx",
+        "outputs": [
+            {
+                "internalType": "bool[]",
+                "name": "successes",
+                "type": "bool[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder[]",
+                "name": "sellOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "signatures",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "revertIfIncomplete",
+                "type": "bool"
+            }
+        ],
+        "name": "batchBuyERC721s",
+        "outputs": [
+            {
+                "internalType": "bool[]",
+                "name": "successes",
+                "type": "bool[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder[]",
+                "name": "sellOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "signatures",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "takers",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "callbackData",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "revertIfIncomplete",
+                "type": "bool"
+            }
+        ],
+        "name": "batchBuyERC721sEx",
+        "outputs": [
+            {
+                "internalType": "bool[]",
+                "name": "successes",
+                "type": "bool[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "orderNonces",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "batchCancelERC1155Orders",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "orderNonces",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "batchCancelERC721Orders",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder[]",
+                "name": "sellOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder[]",
+                "name": "buyOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "sellOrderSignatures",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "buyOrderSignatures",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "batchMatchERC1155Orders",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "profits",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bool[]",
+                "name": "successes",
+                "type": "bool[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder[]",
+                "name": "sellOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder[]",
+                "name": "buyOrders",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "sellOrderSignatures",
+                "type": "tuple[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature[]",
+                "name": "buyOrderSignatures",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "batchMatchERC721Orders",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "profits",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bool[]",
+                "name": "successes",
+                "type": "bool[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint128",
+                "name": "erc1155BuyAmount",
+                "type": "uint128"
+            }
+        ],
+        "name": "buyERC1155",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "internalType": "uint128",
+                "name": "erc1155BuyAmount",
+                "type": "uint128"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "buyERC1155Ex",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            }
+        ],
+        "name": "buyERC721",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "buyERC721Ex",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "orderNonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelERC1155Order",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "orderNonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelERC721Order",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "address",
+                "name": "impl",
+                "type": "address"
+            }
+        ],
+        "name": "extend",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC1155BuyOrderHash",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC1155BuyOrderInfo",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "orderHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "enum LibNFTOrder.OrderStatus",
+                        "name": "status",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "orderAmount",
+                        "type": "uint128"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "remainingAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.OrderInfo",
+                "name": "orderInfo",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC1155SellOrderHash",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC1155SellOrderInfo",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "orderHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "enum LibNFTOrder.OrderStatus",
+                        "name": "status",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "orderAmount",
+                        "type": "uint128"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "remainingAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.OrderInfo",
+                "name": "orderInfo",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC721BuyOrderHash",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC721BuyOrderStatus",
+        "outputs": [
+            {
+                "internalType": "enum LibNFTOrder.OrderStatus",
+                "name": "status",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "internalType": "uint248",
+                "name": "nonceRange",
+                "type": "uint248"
+            }
+        ],
+        "name": "getERC721OrderStatusBitVector",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "bitVector",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC721SellOrderHash",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "getERC721SellOrderStatus",
+        "outputs": [
+            {
+                "internalType": "enum LibNFTOrder.OrderStatus",
+                "name": "status",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            }
+        ],
+        "name": "getHashNonce",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "uint256",
+                "name": "idx",
+                "type": "uint256"
+            }
+        ],
+        "name": "getRollbackEntryAtIndex",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "impl",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            }
+        ],
+        "name": "getRollbackLength",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "incrementHashNonce",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "buyOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "sellOrderSignature",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "buyOrderSignature",
+                "type": "tuple"
+            }
+        ],
+        "name": "matchERC1155Orders",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "profit",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder",
+                "name": "buyOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "sellOrderSignature",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "buyOrderSignature",
+                "type": "tuple"
+            }
+        ],
+        "name": "matchERC721Orders",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "profit",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "migrate",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "success",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "success",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "ownerAddress",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "preSignERC1155BuyOrder",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "preSignERC1155SellOrder",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "preSignERC721BuyOrder",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "preSignERC721SellOrder",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "impl",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes4[]",
+                "name": "methodIDs",
+                "type": "bytes4[]"
+            }
+        ],
+        "name": "registerMethods",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "address",
+                "name": "targetImpl",
+                "type": "address"
+            }
+        ],
+        "name": "rollback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "buyOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint256",
+                "name": "erc1155TokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint128",
+                "name": "erc1155SellAmount",
+                "type": "uint128"
+            },
+            {
+                "internalType": "bool",
+                "name": "unwrapNativeToken",
+                "type": "bool"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "sellERC1155",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder",
+                "name": "buyOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint256",
+                "name": "erc721TokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "unwrapNativeToken",
+                "type": "bool"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "sellERC721",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            }
+        ],
+        "name": "validateERC1155BuyOrderSignature",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            }
+        ],
+        "name": "validateERC1155SellOrderSignature",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "nftProperties",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTBuyOrder",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            }
+        ],
+        "name": "validateERC721BuyOrderSignature",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nftId",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.NFTSellOrder",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            }
+        ],
+        "name": "validateERC721SellOrderSignature",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155SellOrder",
+                "name": "sellOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "address",
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "internalType": "uint128",
+                "name": "erc1155BuyAmount",
+                "type": "uint128"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "buySharedERC1155",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "taker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "expiry",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "erc20Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc20TokenAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "address",
+                                "name": "recipient",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "feeData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Fee[]",
+                        "name": "fees",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "erc1155Token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "erc1155TokenId",
+                        "type": "uint256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "contract IPropertyValidator",
+                                "name": "propertyValidator",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "bytes",
+                                "name": "propertyData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "internalType": "struct LibNFTOrder.Property[]",
+                        "name": "erc1155TokenProperties",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "internalType": "uint128",
+                        "name": "erc1155TokenAmount",
+                        "type": "uint128"
+                    }
+                ],
+                "internalType": "struct LibNFTOrder.ERC1155BuyOrder",
+                "name": "buyOrder",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "enum LibSignature.SignatureType",
+                        "name": "signatureType",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "uint8",
+                        "name": "v",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "r",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "s",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct LibSignature.Signature",
+                "name": "signature",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint256",
+                "name": "erc1155TokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint128",
+                "name": "erc1155SellAmount",
+                "type": "uint128"
+            },
+            {
+                "internalType": "bool",
+                "name": "unwrapNativeToken",
+                "type": "bool"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callbackData",
+                "type": "bytes"
+            }
+        ],
+        "name": "sellSharedERC1155",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/packages/sdk/src/element/addresses.ts
+++ b/packages/sdk/src/element/addresses.ts
@@ -3,3 +3,21 @@ import { ChainIdToAddress, Network } from "../utils";
 export const Exchange: ChainIdToAddress = {
   [Network.Ethereum]: "0x20f780a973856b93f63670377900c1d2a50a77c4",
 };
+
+export const Eth: ChainIdToAddress = {
+  [Network.Ethereum]: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  [Network.EthereumGoerli]: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  [Network.Optimism]: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+};
+
+export const TokenRangeValidator: ChainIdToAddress = {
+  [Network.Ethereum]: "0xf4a4daa2e20f3d249d53e74a15b6a0518c27927d",
+};
+
+export const BitVectorValidator: ChainIdToAddress = {
+  [Network.Ethereum]: "0x345db61cf74cea41c0a58155470020e1392eff2b",
+};
+
+export const PackedListValidator: ChainIdToAddress = {
+  [Network.Ethereum]: "0xda9881fcdf8e73d57727e929380ef20eb50521fe",
+};

--- a/packages/sdk/src/element/builders/base/index.ts
+++ b/packages/sdk/src/element/builders/base/index.ts
@@ -1,0 +1,53 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+import { HashZero } from "@ethersproject/constants";
+
+import { Order } from "../../order";
+import { MatchParams } from "../../types";
+import { getCurrentTimestamp, getRandomBytes } from "../../../utils";
+
+export interface BaseBuildParams {
+  direction: "sell" | "buy";
+  contract: string;
+  maker: string;
+  paymentToken: string;
+  price: BigNumberish;
+  fees?: {
+    recipient: string;
+    amount: BigNumberish;
+  }[];
+  amount?: BigNumberish;
+  expiry?: number;
+  nonce?: BigNumberish;
+  signatureType?: number;
+  v?: number;
+  r?: string;
+  s?: string;
+}
+
+export interface BaseOrderInfo {}
+
+export abstract class BaseBuilder {
+  public chainId: number;
+
+  constructor(chainId: number) {
+    this.chainId = chainId;
+  }
+
+  protected defaultInitialize(params: BaseBuildParams) {
+    params.fees = params.fees ?? [];
+    params.expiry = params.expiry ?? getCurrentTimestamp(365 * 24 * 60 * 60);
+    params.nonce = params.nonce ?? getRandomBytes();
+    params.signatureType = params.signatureType ?? 2;
+    params.v = params.v ?? 0;
+    params.r = params.r ?? HashZero;
+    params.s = params.s ?? HashZero;
+  }
+
+  public getInfo(_order: Order): BaseOrderInfo {
+    return {};
+  }
+
+  public abstract isValid(order: Order): boolean;
+  public abstract build(params: BaseBuildParams): Order;
+  public abstract buildMatching(order: Order, data: any): MatchParams;
+}

--- a/packages/sdk/src/element/builders/contract-wide/index.ts
+++ b/packages/sdk/src/element/builders/contract-wide/index.ts
@@ -1,0 +1,92 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+import { AddressZero } from "@ethersproject/constants";
+
+import { BaseBuildParams, BaseBuilder } from "../base";
+import * as Addresses from "../../addresses";
+import { Order } from "../../order";
+import * as Types from "../../types";
+import * as CommonAddresses from "../../../common/addresses";
+import { BytesEmpty, lc, s } from "../../../utils";
+
+interface BuildParams extends BaseBuildParams {}
+
+export class ContractWideBuilder extends BaseBuilder {
+  public isValid(order: Order): boolean {
+    try {
+      const copyOrder = this.build({
+        ...order.params,
+        direction:
+          order.params.direction === Types.TradeDirection.SELL ? "sell" : "buy",
+        contract: order.params.nft,
+        maker: order.params.maker,
+        paymentToken: order.params.erc20Token,
+        price: order.params.erc20TokenAmount,
+        amount: order.params.nftAmount,
+      });
+
+      if (!copyOrder) {
+        return false;
+      }
+
+      if (copyOrder.hash() !== order.hash()) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    return true;
+  }
+
+  public build(params: BuildParams) {
+    this.defaultInitialize(params);
+
+    return new Order(this.chainId, {
+      kind: params.amount ? "erc1155-contract-wide" : "erc721-contract-wide",
+      direction:
+        params.direction === "sell"
+          ? Types.TradeDirection.SELL
+          : Types.TradeDirection.BUY,
+      maker: params.maker,
+      taker: AddressZero,
+      expiry: params.expiry!,
+      nonce: s(params.nonce)!,
+      erc20Token: params.paymentToken,
+      erc20TokenAmount: s(params.price),
+      fees: params.fees!.map(({ recipient, amount }) => ({
+        recipient: lc(recipient),
+        amount: s(amount),
+        feeData: BytesEmpty,
+      })),
+      nft: params.contract,
+      nftId: "0",
+      nftProperties: [
+        {
+          // The zero address is basically a no-op (will accept any token id).
+          propertyValidator: AddressZero,
+          propertyData: "0x",
+        },
+      ],
+      nftAmount: params.amount ? s(params.amount) : undefined,
+      signatureType: params.signatureType,
+      v: params.v,
+      r: params.r,
+      s: params.s,
+    });
+  }
+
+  public buildMatching(
+    _order: Order,
+    data: {
+      tokenId: BigNumberish;
+      amount?: BigNumberish;
+      unwrapNativeToken?: boolean;
+    }
+  ) {
+    return {
+      nftId: s(data.tokenId),
+      nftAmount: data.amount ? s(data.amount) : "1",
+      unwrapNativeToken: data.unwrapNativeToken,
+    };
+  }
+}

--- a/packages/sdk/src/element/builders/index.ts
+++ b/packages/sdk/src/element/builders/index.ts
@@ -1,0 +1,15 @@
+import { ContractWideBuilder } from "./contract-wide";
+import { SingleTokenBuilder } from "./single-token";
+import { BitVectorTokenListBuilder } from "./token-list/bit-vector";
+import { PackedListTokenListBuilder } from "./token-list/packed-list";
+import { TokenRangeBuilder } from "./token-range";
+
+export const Builders = {
+  ContractWide: ContractWideBuilder,
+  SingleToken: SingleTokenBuilder,
+  TokenList: {
+    BitVector: BitVectorTokenListBuilder,
+    PackedList: PackedListTokenListBuilder,
+  },
+  TokenRange: TokenRangeBuilder,
+};

--- a/packages/sdk/src/element/builders/single-token/index.ts
+++ b/packages/sdk/src/element/builders/single-token/index.ts
@@ -1,0 +1,85 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+import { AddressZero } from "@ethersproject/constants";
+
+import { BaseBuildParams, BaseBuilder } from "../base";
+import * as Addresses from "../../addresses";
+import { Order } from "../../order";
+import * as Types from "../../types";
+import * as CommonAddresses from "../../../common/addresses";
+import { BytesEmpty, lc, s } from "../../../utils";
+
+interface BuildParams extends BaseBuildParams {
+  tokenId: BigNumberish;
+}
+
+export class SingleTokenBuilder extends BaseBuilder {
+  public isValid(order: Order): boolean {
+    try {
+      const copyOrder = this.build({
+        ...order.params,
+        direction:
+          order.params.direction === Types.TradeDirection.SELL ? "sell" : "buy",
+        contract: order.params.nft,
+        maker: order.params.maker,
+        paymentToken: order.params.erc20Token,
+        price: order.params.erc20TokenAmount,
+        amount: order.params.nftAmount,
+        tokenId: order.params.nftId,
+      });
+
+      if (!copyOrder) {
+        return false;
+      }
+
+      if (copyOrder.hash() !== order.hash()) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    return true;
+  }
+
+  public build(params: BuildParams) {
+    this.defaultInitialize(params);
+
+    return new Order(this.chainId, {
+      kind: params.amount ? "erc1155-single-token" : "erc721-single-token",
+      direction:
+        params.direction === "sell"
+          ? Types.TradeDirection.SELL
+          : Types.TradeDirection.BUY,
+      maker: params.maker,
+      taker: AddressZero,
+      expiry: params.expiry!,
+      nonce: s(params.nonce)!,
+      erc20Token: params.paymentToken,
+      erc20TokenAmount: s(params.price),
+      fees: params.fees!.map(({ recipient, amount }) => ({
+        recipient: lc(recipient),
+        amount: s(amount),
+        feeData: BytesEmpty,
+      })),
+      nft: params.contract,
+      nftId: s(params.tokenId),
+      nftProperties: [],
+      nftAmount: params.amount ? s(params.amount) : undefined,
+      signatureType: params.signatureType,
+      v: params.v,
+      r: params.r,
+      s: params.s,
+    });
+  }
+
+  public buildMatching(
+    order: Order,
+    data?: { amount?: BigNumberish; unwrapNativeToken?: boolean }
+  ) {
+    return {
+      nftId: order.params.nftId,
+      nftAmount: data?.amount ? s(data.amount) : "1",
+      unwrapNativeToken: data?.unwrapNativeToken,
+    };
+  }
+}

--- a/packages/sdk/src/element/builders/token-list/bit-vector/index.ts
+++ b/packages/sdk/src/element/builders/token-list/bit-vector/index.ts
@@ -1,0 +1,113 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+import { AddressZero } from "@ethersproject/constants";
+
+import { BaseBuildParams, BaseBuilder, BaseOrderInfo } from "../../base";
+import * as Addresses from "../../../addresses";
+import { Order } from "../../../order";
+import * as Types from "../../../types";
+import * as CommonAddresses from "../../../../common/addresses";
+import {
+  decomposeBitVector,
+  generateBitVector,
+} from "../../../../common/helpers/bit-vector";
+import { BytesEmpty, lc, s } from "../../../../utils";
+
+interface BuildParams extends BaseBuildParams {
+  tokenIds: BigNumberish[];
+}
+
+interface OrderInfo extends BaseOrderInfo {
+  tokenIds: BigNumberish[];
+}
+
+export class BitVectorTokenListBuilder extends BaseBuilder {
+  public isValid(order: Order): boolean {
+    try {
+      const copyOrder = this.build({
+        ...order.params,
+        direction:
+          order.params.direction === Types.TradeDirection.SELL ? "sell" : "buy",
+        contract: order.params.nft,
+        maker: order.params.maker,
+        paymentToken: order.params.erc20Token,
+        price: order.params.erc20TokenAmount,
+        amount: order.params.nftAmount,
+        tokenIds: decomposeBitVector(
+          order.params.nftProperties[0].propertyData
+        ),
+      });
+
+      if (!copyOrder) {
+        return false;
+      }
+
+      if (copyOrder.hash() !== order.hash()) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    return true;
+  }
+
+  public build(params: BuildParams) {
+    this.defaultInitialize(params);
+
+    return new Order(this.chainId, {
+      kind: params.amount
+        ? "erc1155-token-list-bit-vector"
+        : "erc721-token-list-bit-vector",
+      direction:
+        params.direction === "sell"
+          ? Types.TradeDirection.SELL
+          : Types.TradeDirection.BUY,
+      maker: params.maker,
+      taker: AddressZero,
+      expiry: params.expiry!,
+      nonce: s(params.nonce)!,
+      erc20Token: params.paymentToken,
+      erc20TokenAmount: s(params.price),
+      fees: params.fees!.map(({ recipient, amount }) => ({
+        recipient: lc(recipient),
+        amount: s(amount),
+        feeData: BytesEmpty,
+      })),
+      nft: params.contract,
+      nftId: "0",
+      nftProperties: [
+        {
+          propertyValidator: Addresses.BitVectorValidator[this.chainId],
+          propertyData: generateBitVector(params.tokenIds.map(Number)),
+        },
+      ],
+      nftAmount: params.amount ? s(params.amount) : undefined,
+      signatureType: params.signatureType,
+      v: params.v,
+      r: params.r,
+      s: params.s,
+    });
+  }
+
+  public buildMatching(
+    _order: Order,
+    data: {
+      tokenId: BigNumberish;
+      amount?: BigNumberish;
+      unwrapNativeToken?: boolean;
+    }
+  ) {
+    return {
+      nftId: s(data.tokenId),
+      nftAmount: data.amount ? s(data.amount) : "1",
+      unwrapNativeToken: data.unwrapNativeToken,
+    };
+  }
+
+  public getInfo(order: Order): OrderInfo {
+    const tokenIds = decomposeBitVector(
+      order.params.nftProperties[0].propertyData
+    );
+    return { tokenIds };
+  }
+}

--- a/packages/sdk/src/element/builders/token-list/packed-list/index.ts
+++ b/packages/sdk/src/element/builders/token-list/packed-list/index.ts
@@ -1,0 +1,113 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+import { AddressZero } from "@ethersproject/constants";
+
+import { BaseBuildParams, BaseBuilder, BaseOrderInfo } from "../../base";
+import * as Addresses from "../../../addresses";
+import { Order } from "../../../order";
+import * as Types from "../../../types";
+import * as CommonAddresses from "../../../../common/addresses";
+import {
+  decomposePackedList,
+  generatePackedList,
+} from "../../../../common/helpers/packed-list";
+import { BytesEmpty, lc, s } from "../../../../utils";
+
+interface BuildParams extends BaseBuildParams {
+  tokenIds: BigNumberish[];
+}
+
+interface OrderInfo extends BaseOrderInfo {
+  tokenIds: BigNumberish[];
+}
+
+export class PackedListTokenListBuilder extends BaseBuilder {
+  public isValid(order: Order): boolean {
+    try {
+      const copyOrder = this.build({
+        ...order.params,
+        direction:
+          order.params.direction === Types.TradeDirection.SELL ? "sell" : "buy",
+        contract: order.params.nft,
+        maker: order.params.maker,
+        paymentToken: order.params.erc20Token,
+        price: order.params.erc20TokenAmount,
+        amount: order.params.nftAmount,
+        tokenIds: decomposePackedList(
+          order.params.nftProperties[0].propertyData
+        ),
+      });
+
+      if (!copyOrder) {
+        return false;
+      }
+
+      if (copyOrder.hash() !== order.hash()) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    return true;
+  }
+
+  public build(params: BuildParams) {
+    this.defaultInitialize(params);
+
+    return new Order(this.chainId, {
+      kind: params.amount
+        ? "erc1155-token-list-packed-list"
+        : "erc721-token-list-packed-list",
+      direction:
+        params.direction === "sell"
+          ? Types.TradeDirection.SELL
+          : Types.TradeDirection.BUY,
+      maker: params.maker,
+      taker: AddressZero,
+      expiry: params.expiry!,
+      nonce: s(params.nonce)!,
+      erc20Token: params.paymentToken,
+      erc20TokenAmount: s(params.price),
+      fees: params.fees!.map(({ recipient, amount }) => ({
+        recipient: lc(recipient),
+        amount: s(amount),
+        feeData: BytesEmpty,
+      })),
+      nft: params.contract,
+      nftId: "0",
+      nftProperties: [
+        {
+          propertyValidator: Addresses.PackedListValidator[this.chainId],
+          propertyData: generatePackedList(params.tokenIds),
+        },
+      ],
+      nftAmount: params.amount ? s(params.amount) : undefined,
+      signatureType: params.signatureType,
+      v: params.v,
+      r: params.r,
+      s: params.s,
+    });
+  }
+
+  public buildMatching(
+    _order: Order,
+    data: {
+      tokenId: BigNumberish;
+      amount?: BigNumberish;
+      unwrapNativeToken?: boolean;
+    }
+  ) {
+    return {
+      nftId: s(data.tokenId),
+      nftAmount: data.amount ? s(data.amount) : "1",
+      unwrapNativeToken: data.unwrapNativeToken,
+    };
+  }
+
+  public getInfo(order: Order): OrderInfo {
+    const tokenIds = decomposePackedList(
+      order.params.nftProperties[0].propertyData
+    );
+    return { tokenIds };
+  }
+}

--- a/packages/sdk/src/element/builders/token-range/index.ts
+++ b/packages/sdk/src/element/builders/token-range/index.ts
@@ -1,0 +1,119 @@
+import { defaultAbiCoder } from "@ethersproject/abi";
+import { BigNumberish } from "@ethersproject/bignumber";
+import { AddressZero } from "@ethersproject/constants";
+
+import { BaseBuildParams, BaseBuilder, BaseOrderInfo } from "../base";
+import * as Addresses from "../../addresses";
+import { Order } from "../../order";
+import * as Types from "../../types";
+import * as CommonAddresses from "../../../common/addresses";
+import { BytesEmpty, lc, s } from "../../../utils";
+
+interface BuildParams extends BaseBuildParams {
+  startTokenId: BigNumberish;
+  endTokenId: BigNumberish;
+}
+
+interface OrderInfo extends BaseOrderInfo {
+  startTokenId: BigNumberish;
+  endTokenId: BigNumberish;
+}
+
+export class TokenRangeBuilder extends BaseBuilder {
+  public isValid(order: Order): boolean {
+    try {
+      const [startTokenId, endTokenId] = defaultAbiCoder.decode(
+        ["uint256", "uint256"],
+        order.params.nftProperties[0].propertyData
+      );
+
+      const copyOrder = this.build({
+        ...order.params,
+        direction:
+          order.params.direction === Types.TradeDirection.SELL ? "sell" : "buy",
+        contract: order.params.nft,
+        maker: order.params.maker,
+        paymentToken: order.params.erc20Token,
+        price: order.params.erc20TokenAmount,
+        amount: order.params.nftAmount,
+        startTokenId,
+        endTokenId,
+      });
+
+      if (!copyOrder) {
+        return false;
+      }
+
+      if (copyOrder.hash() !== order.hash()) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    return true;
+  }
+
+  public build(params: BuildParams) {
+    this.defaultInitialize(params);
+
+    return new Order(this.chainId, {
+      kind: params.amount ? "erc1155-token-range" : "erc721-token-range",
+      direction:
+        params.direction === "sell"
+          ? Types.TradeDirection.SELL
+          : Types.TradeDirection.BUY,
+      maker: params.maker,
+      taker: AddressZero,
+      expiry: params.expiry!,
+      nonce: s(params.nonce)!,
+      erc20Token: params.paymentToken,
+      erc20TokenAmount: s(params.price),
+      fees: params.fees!.map(({ recipient, amount }) => ({
+        recipient: lc(recipient),
+        amount: s(amount),
+        feeData: BytesEmpty,
+      })),
+      nft: params.contract,
+      nftId: "0",
+      nftProperties: [
+        {
+          propertyValidator: Addresses.TokenRangeValidator[this.chainId],
+          propertyData: defaultAbiCoder.encode(
+            ["uint256", "uint256"],
+            [s(params.startTokenId), s(params.endTokenId)]
+          ),
+        },
+      ],
+      nftAmount: params.amount ? s(params.amount) : undefined,
+      signatureType: params.signatureType,
+      v: params.v,
+      r: params.r,
+      s: params.s,
+    });
+  }
+
+  public buildMatching(
+    _order: Order,
+    data: {
+      tokenId: BigNumberish;
+      amount?: BigNumberish;
+      unwrapNativeToken?: boolean;
+    }
+  ) {
+    return {
+      nftId: s(data.tokenId),
+      nftAmount: data.amount ? s(data.amount) : "1",
+      unwrapNativeToken: data.unwrapNativeToken,
+    };
+  }
+
+  public getInfo(order: Order): OrderInfo {
+    const [startTokenId, endTokenId] = defaultAbiCoder.decode(
+      ["uint256", "uint256"],
+      order.params.nftProperties[0].propertyData
+    );
+
+    return { startTokenId, endTokenId };
+  }
+}

--- a/packages/sdk/src/element/exchange.ts
+++ b/packages/sdk/src/element/exchange.ts
@@ -1,0 +1,264 @@
+import { defaultAbiCoder } from "@ethersproject/abi";
+import { Signer } from "@ethersproject/abstract-signer";
+import { BigNumber } from "@ethersproject/bignumber";
+import { Contract, ContractTransaction } from "@ethersproject/contracts";
+
+import * as Addresses from "./addresses";
+import { Order } from "./order";
+import * as Types from "./types";
+import { BytesEmpty, TxData, bn, generateReferrerBytes } from "../utils";
+
+import ExchangeAbi from "./abis/Exchange.json";
+import Erc721Abi from "../common/abis/Erc721.json";
+import Erc1155Abi from "../common/abis/Erc1155.json";
+
+export class Exchange {
+  public chainId: number;
+  public contract: Contract;
+
+  constructor(chainId: number) {
+    this.chainId = chainId;
+    this.contract = new Contract(Addresses.Exchange[this.chainId], ExchangeAbi);
+  }
+
+  // --- Fill order ---
+
+  public async fillOrder(
+    taker: Signer,
+    order: Order,
+    matchParams: Types.MatchParams,
+    options?: {
+      noDirectTransfer?: boolean;
+      referrer?: string;
+    }
+  ): Promise<ContractTransaction> {
+    const tx = this.fillOrderTx(
+      await taker.getAddress(),
+      order,
+      matchParams,
+      options
+    );
+    return taker.sendTransaction(tx);
+  }
+
+  public fillOrderTx(
+    taker: string,
+    order: Order,
+    matchParams: Types.MatchParams,
+    options?: {
+      noDirectTransfer?: boolean;
+      referrer?: string;
+    }
+  ): TxData {
+    const feeAmount = order.getFeeAmount();
+
+    let to = this.contract.address;
+    let data: string;
+    let value: BigNumber | undefined;
+
+    if (order.params.kind?.startsWith("erc721")) {
+      const erc721 = new Contract(order.params.nft, Erc721Abi);
+      if (order.params.direction === Types.TradeDirection.BUY) {
+          data = this.contract.interface.encodeFunctionData("sellERC721", [
+            order.getRaw(),
+            order.getRaw(),
+            matchParams.nftId!,
+            matchParams.unwrapNativeToken ?? true,
+            BytesEmpty,
+          ]);
+      } else {
+        data = this.contract.interface.encodeFunctionData("buyERC721", [
+          order.getRaw(),
+          order.getRaw(),
+        ]);
+        value = bn(order.params.erc20TokenAmount).add(feeAmount);
+      }
+    } else {
+      const erc1155 = new Contract(order.params.nft, Erc1155Abi);
+      if (order.params.direction === Types.TradeDirection.BUY) {
+        data = this.contract.interface.encodeFunctionData("sellERC1155", [
+          order.getRaw(),
+          order.getRaw(),
+          matchParams.nftId!,
+          matchParams.nftAmount!,
+          matchParams.unwrapNativeToken ?? true,
+          BytesEmpty,
+        ]);
+      } else {
+        data = this.contract.interface.encodeFunctionData("buyERC1155", [
+          order.getRaw(),
+          order.getRaw(),
+          matchParams.nftAmount!,
+        ]);
+        value = bn(matchParams.nftAmount!)
+          .mul(order.params.erc20TokenAmount)
+          .add(order.params.nftAmount!)
+          .sub(1)
+          .div(order.params.nftAmount!)
+          // Buyer pays the fees
+          .add(
+            feeAmount.mul(matchParams.nftAmount!).div(order.params.nftAmount!)
+          );
+      }
+    }
+
+    return {
+      from: taker,
+      to,
+      data: data + generateReferrerBytes(options?.referrer),
+      value: value && bn(value).toHexString(),
+    };
+  }
+
+  // --- Batch fill listings ---
+
+  public async batchBuy(
+    taker: Signer,
+    orders: Order[],
+    matchParams: Types.MatchParams[],
+    options?: {
+      referrer?: string;
+    }
+  ): Promise<ContractTransaction> {
+    const tx = this.batchBuyTx(
+      await taker.getAddress(),
+      orders,
+      matchParams,
+      options
+    );
+    return taker.sendTransaction(tx);
+  }
+
+  public batchBuyTx(
+    taker: string,
+    orders: Order[],
+    matchParams: Types.MatchParams[],
+    options?: {
+      referrer?: string;
+    }
+  ): TxData {
+    const sellOrders: any[] = [];
+    const signatures: any[] = [];
+    const fillAmounts: string[] = [];
+    const callbackData: string[] = [];
+
+    const tokenKind = orders[0].params.kind?.split("-")[0];
+    if (!tokenKind) {
+      throw new Error("Could not detect token kind");
+    }
+
+    let value = bn(0);
+    for (let i = 0; i < Math.min(orders.length, matchParams.length); i++) {
+      if (orders[i].params.direction !== Types.TradeDirection.SELL) {
+        throw new Error("Invalid side");
+      }
+      if (orders[i].params.kind?.split("-")[0] !== tokenKind) {
+        throw new Error("Invalid kind");
+      }
+
+      const feeAmount = orders[i].getFeeAmount();
+      value = value.add(
+        bn(matchParams[i].nftAmount!)
+          .mul(orders[i].params.erc20TokenAmount)
+          .add(orders[i].params.nftAmount!)
+          .sub(1)
+          .div(orders[i].params.nftAmount!)
+          // Buyer pays the fees
+          .add(
+            feeAmount
+              .mul(matchParams[i].nftAmount!)
+              .div(orders[i].params.nftAmount!)
+          )
+      );
+
+      sellOrders.push(orders[i].getRaw());
+      signatures.push(orders[i].getRaw());
+      fillAmounts.push(matchParams[i].nftAmount!);
+      callbackData.push(BytesEmpty);
+    }
+
+    return {
+      from: taker,
+      to: this.contract.address,
+      data:
+        (tokenKind === "erc1155"
+          ? this.contract.interface.encodeFunctionData("batchBuyERC1155s", [
+              sellOrders,
+              signatures,
+              fillAmounts,
+              false,
+            ])
+          : this.contract.interface.encodeFunctionData("batchBuyERC721s", [
+              sellOrders,
+              signatures,
+              false,
+            ])) + generateReferrerBytes(options?.referrer),
+      value: value && bn(value).toHexString(),
+    };
+  }
+
+  // --- Cancel order ---
+
+  public async cancelOrder(
+    maker: Signer,
+    order: Order
+  ): Promise<ContractTransaction> {
+    const tx = this.cancelOrderTx(await maker.getAddress(), order);
+    return maker.sendTransaction(tx);
+  }
+
+  public cancelOrderTx(maker: string, order: Order): TxData {
+    let data: string;
+    if (order.params.kind?.startsWith("erc721")) {
+      data = this.contract.interface.encodeFunctionData("cancelERC721Order", [
+        order.params.nonce,
+      ]);
+    } else {
+      data = this.contract.interface.encodeFunctionData("cancelERC1155Order", [
+        order.params.nonce,
+      ]);
+    }
+
+    return {
+      from: maker,
+      to: this.contract.address,
+      data,
+    };
+  }
+}
+
+const Erc721OrderAbiType = `(
+  uint8 direction,
+  address maker,
+  address taker,
+  uint256 expiry,
+  uint256 nonce,
+  address erc20Token,
+  uint256 erc20TokenAmount,
+  (address recipient, uint256 amount, bytes feeData)[] fees,
+  address erc721Token,
+  uint256 erc721TokenId,
+  (address propertyValidator, bytes propertyData)[] erc721TokenProperties
+)`;
+
+const Erc1155OrderAbiType = `(
+  uint8 direction,
+  address maker,
+  address taker,
+  uint256 expiry,
+  uint256 nonce,
+  address erc20Token,
+  uint256 erc20TokenAmount,
+  (address recipient, uint256 amount, bytes feeData)[] fees,
+  address erc1155Token,
+  uint256 erc1155TokenId,
+  (address propertyValidator, bytes propertyData)[] erc1155TokenProperties,
+  uint128 erc1155TokenAmount
+)`;
+
+const SignatureAbiType = `(
+  uint8 signatureType,
+  uint8 v,
+  bytes32 r,
+  bytes32 s
+)`;

--- a/packages/sdk/src/element/exchange.ts
+++ b/packages/sdk/src/element/exchange.ts
@@ -1,4 +1,3 @@
-import { defaultAbiCoder } from "@ethersproject/abi";
 import { Signer } from "@ethersproject/abstract-signer";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Contract, ContractTransaction } from "@ethersproject/contracts";
@@ -9,8 +8,6 @@ import * as Types from "./types";
 import { BytesEmpty, TxData, bn, generateReferrerBytes } from "../utils";
 
 import ExchangeAbi from "./abis/Exchange.json";
-import Erc721Abi from "../common/abis/Erc721.json";
-import Erc1155Abi from "../common/abis/Erc1155.json";
 
 export class Exchange {
   public chainId: number;
@@ -57,7 +54,6 @@ export class Exchange {
     let value: BigNumber | undefined;
 
     if (order.params.kind?.startsWith("erc721")) {
-      const erc721 = new Contract(order.params.nft, Erc721Abi);
       if (order.params.direction === Types.TradeDirection.BUY) {
           data = this.contract.interface.encodeFunctionData("sellERC721", [
             order.getRaw(),
@@ -74,7 +70,6 @@ export class Exchange {
         value = bn(order.params.erc20TokenAmount).add(feeAmount);
       }
     } else {
-      const erc1155 = new Contract(order.params.nft, Erc1155Abi);
       if (order.params.direction === Types.TradeDirection.BUY) {
         data = this.contract.interface.encodeFunctionData("sellERC1155", [
           order.getRaw(),
@@ -226,39 +221,3 @@ export class Exchange {
     };
   }
 }
-
-const Erc721OrderAbiType = `(
-  uint8 direction,
-  address maker,
-  address taker,
-  uint256 expiry,
-  uint256 nonce,
-  address erc20Token,
-  uint256 erc20TokenAmount,
-  (address recipient, uint256 amount, bytes feeData)[] fees,
-  address erc721Token,
-  uint256 erc721TokenId,
-  (address propertyValidator, bytes propertyData)[] erc721TokenProperties
-)`;
-
-const Erc1155OrderAbiType = `(
-  uint8 direction,
-  address maker,
-  address taker,
-  uint256 expiry,
-  uint256 nonce,
-  address erc20Token,
-  uint256 erc20TokenAmount,
-  (address recipient, uint256 amount, bytes feeData)[] fees,
-  address erc1155Token,
-  uint256 erc1155TokenId,
-  (address propertyValidator, bytes propertyData)[] erc1155TokenProperties,
-  uint128 erc1155TokenAmount
-)`;
-
-const SignatureAbiType = `(
-  uint8 signatureType,
-  uint8 v,
-  bytes32 r,
-  bytes32 s
-)`;

--- a/packages/sdk/src/element/index.ts
+++ b/packages/sdk/src/element/index.ts
@@ -1,3 +1,7 @@
 import * as Addresses from "./addresses";
+import { Builders } from "./builders";
+import { Exchange } from "./exchange";
+import { Order } from "./order";
+import * as Types from "./types";
 
-export { Addresses };
+export { Addresses, Builders, Exchange, Order, Types };

--- a/packages/sdk/src/element/order.ts
+++ b/packages/sdk/src/element/order.ts
@@ -1,0 +1,465 @@
+import { Provider } from "@ethersproject/abstract-provider";
+import { TypedDataSigner, VoidSigner } from "@ethersproject/abstract-signer";
+import { BigNumber } from "@ethersproject/bignumber";
+import { splitSignature } from "@ethersproject/bytes";
+import { HashZero } from "@ethersproject/constants";
+import { Contract } from "@ethersproject/contracts";
+import { _TypedDataEncoder } from "@ethersproject/hash";
+import { verifyTypedData } from "@ethersproject/wallet";
+
+import * as Addresses from "./addresses";
+import { Builders } from "./builders";
+import { BaseBuilder, BaseOrderInfo } from "./builders/base";
+import * as Types from "./types";
+import * as Common from "../common";
+import { bn, lc, n, s } from "../utils";
+
+import ExchangeAbi from "./abis/Exchange.json";
+
+export class Order {
+  public chainId: number;
+  public params: Types.BaseOrder;
+
+  constructor(chainId: number, params: Types.BaseOrder) {
+    this.chainId = chainId;
+
+    try {
+      this.params = normalize(params);
+    } catch {
+      throw new Error("Invalid params");
+    }
+
+    // Detect kind
+    if (!params.kind) {
+      this.params.kind = this.detectKind();
+    }
+  }
+
+  public getRaw() {
+    const raw =  this.params.kind?.startsWith("erc721")
+    ? toRawErc721Order(this)
+    : toRawErc1155Order(this);
+    return raw;
+  }
+
+  public hash() {
+    const [types, value, structName] = this.getEip712TypesAndValue();
+    return _TypedDataEncoder.hashStruct(structName, types, value);
+  }
+
+  public async sign(signer: TypedDataSigner, provider: Provider) {
+    const [types, value] = this.getEip712TypesAndValue();
+    const exchange = new Contract(
+      Addresses.Exchange[this.chainId],
+      ExchangeAbi as any,
+      provider
+    );
+
+    const hashNonce = await exchange.getHashNonce((signer as VoidSigner).address);
+    // add hashNonce
+    value.hashNonce = hashNonce;
+
+    const { v, r, s } = splitSignature(
+      await signer._signTypedData(EIP712_DOMAIN(this.chainId), types, value)
+    );
+
+    this.params = {
+      ...this.params,
+      signatureType: 0,
+      v,
+      r,
+      s,
+    };
+  }
+
+  public getSignatureData() {
+    const [types, value] = this.getEip712TypesAndValue();
+    return {
+      signatureKind: "eip712",
+      domain: EIP712_DOMAIN(this.chainId),
+      types,
+      value,
+    };
+  }
+
+  public checkSignature() {
+    const [types, value] = this.getEip712TypesAndValue();
+
+    const signer = verifyTypedData(EIP712_DOMAIN(this.chainId), types, value, {
+      v: this.params.v,
+      r: this.params.r ?? "",
+      s: this.params.s ?? "",
+    });
+
+    if (lc(this.params.maker) !== lc(signer)) {
+      throw new Error("Invalid signature");
+    }
+  }
+
+  public checkValidity() {
+    if (!this.getBuilder().isValid(this)) {
+      throw new Error("Invalid order");
+    }
+  }
+
+  public getInfo(): BaseOrderInfo | undefined {
+    return this.getBuilder().getInfo(this);
+  }
+
+  public async checkFillability(provider: Provider) {
+    const chainId = await provider.getNetwork().then((n) => n.chainId);
+
+    const exchange = new Contract(
+      Addresses.Exchange[this.chainId],
+      ExchangeAbi as any,
+      provider
+    );
+
+    let status: number | undefined;
+    if (this.params.kind?.startsWith("erc721")) {
+      status = this.params.direction === Types.TradeDirection.SELL 
+        ? await exchange.getERC721SellOrderStatus(toRawErc721Order(this)) : 
+        await exchange.getERC721BuyOrderStatus(toRawErc721Order(this));
+    } else {
+      ({ status } = this.params.direction === Types.TradeDirection.SELL ?
+        await exchange.getERC1155SellOrderInfo(
+          toRawErc1155Order(this)
+        )
+        : await exchange.getERC1155BuyOrderInfo(
+          toRawErc1155Order(this)
+        )
+      );
+    }
+
+    if (status !== 1) {
+      throw new Error("not-fillable");
+    }
+
+    // Determine the order's fees (which are to be payed by the buyer)
+    let feeAmount = this.getFeeAmount();
+
+    if (this.params.direction === Types.TradeDirection.BUY) {
+      // Check that maker has enough balance to cover the payment
+      // and the approval to the token transfer proxy is set
+      const erc20 = new Common.Helpers.Erc20(provider, this.params.erc20Token);
+      const balance = await erc20.getBalance(this.params.maker);
+      if (bn(balance).lt(bn(this.params.erc20TokenAmount).add(feeAmount))) {
+        throw new Error("no-balance");
+      }
+
+      // Check allowance
+      const allowance = await erc20.getAllowance(
+        this.params.maker,
+        Addresses.Exchange[chainId]
+      );
+      if (bn(allowance).lt(bn(this.params.erc20TokenAmount).add(feeAmount))) {
+        throw new Error("no-approval");
+      }
+    } else {
+      if (this.params.kind?.startsWith("erc721")) {
+        const erc721 = new Common.Helpers.Erc721(provider, this.params.nft);
+
+        // Check ownership
+        const owner = await erc721.getOwner(this.params.nftId);
+        if (lc(owner) !== lc(this.params.maker)) {
+          throw new Error("no-balance");
+        }
+
+        // Check approval
+        const isApproved = await erc721.isApproved(
+          this.params.maker,
+          Addresses.Exchange[this.chainId]
+        );
+        if (!isApproved) {
+          throw new Error("no-approval");
+        }
+      } else {
+        const erc1155 = new Common.Helpers.Erc1155(provider, this.params.nft);
+
+        // Check balance
+        const balance = await erc1155.getBalance(
+          this.params.maker,
+          this.params.nftId
+        );
+        if (bn(balance).lt(this.params.nftAmount!)) {
+          throw new Error("no-balance");
+        }
+
+        // Check approval
+        const isApproved = await erc1155.isApproved(
+          this.params.maker,
+          Addresses.Exchange[this.chainId]
+        );
+        if (!isApproved) {
+          throw new Error("no-approval");
+        }
+      }
+    }
+  }
+
+  public buildMatching(data?: any) {
+    return this.getBuilder().buildMatching(this, data);
+  }
+
+  public getFeeAmount(): BigNumber {
+    let feeAmount = bn(0);
+    for (const { amount } of this.params.fees) {
+      feeAmount = feeAmount.add(amount);
+    }
+    return feeAmount;
+  }
+
+  private getEip712TypesAndValue() {
+    const isSell = this.params.direction === Types.TradeDirection.SELL;
+    if (!this.params.nftAmount) {
+      if (isSell) {
+        return [NFT_SELL_ORDER_EIP712_TYPES, toRawErc721Order(this), "NFTSellOrder"]
+      } else {
+        return [NFT_BUY_ORDER_EIP712_TYPES, toRawErc721Order(this), "NFTBuyOrder"]
+      }
+    } else {
+      if (isSell) {
+        return [ERC1155_SELL_ORDER_EIP712_TYPES, toRawErc1155Order(this), "ERC1155SellOrder"];
+      } else {
+        return [ERC1155_BUY_ORDER_EIP712_TYPES, toRawErc1155Order(this), "ERC1155BuyOrder"];
+      }
+    }
+  }
+
+  private getBuilder(): BaseBuilder {
+    switch (this.params.kind) {
+      case "erc721-contract-wide":
+      case "erc1155-contract-wide": {
+        return new Builders.ContractWide(this.chainId);
+      }
+
+      case "erc721-single-token":
+      case "erc1155-single-token": {
+        return new Builders.SingleToken(this.chainId);
+      }
+
+      case "erc721-token-range":
+      case "erc1155-token-range": {
+        return new Builders.TokenRange(this.chainId);
+      }
+
+      case "erc721-token-list-bit-vector":
+      case "erc1155-token-list-bit-vector": {
+        return new Builders.TokenList.BitVector(this.chainId);
+      }
+
+      case "erc721-token-list-packed-list":
+      case "erc1155-token-list-packed-list": {
+        return new Builders.TokenList.PackedList(this.chainId);
+      }
+
+      default: {
+        throw new Error("Unknown order kind");
+      }
+    }
+  }
+
+  private detectKind(): Types.OrderKind {
+    // contract-wide
+    {
+      const builder = new Builders.ContractWide(this.chainId);
+      if (builder.isValid(this)) {
+        return this.params.nftAmount
+          ? "erc1155-contract-wide"
+          : "erc721-contract-wide";
+      }
+    }
+
+    // single-token
+    {
+      const builder = new Builders.SingleToken(this.chainId);
+      if (builder.isValid(this)) {
+        return this.params.nftAmount
+          ? "erc1155-single-token"
+          : "erc721-single-token";
+      }
+    }
+
+    // token-range
+    {
+      const builder = new Builders.TokenRange(this.chainId);
+      if (builder.isValid(this)) {
+        return this.params.nftAmount
+          ? "erc1155-token-range"
+          : "erc721-token-range";
+      }
+    }
+
+    // token-list
+    {
+      const builder = new Builders.TokenList.BitVector(this.chainId);
+      if (builder.isValid(this)) {
+        return this.params.nftAmount
+          ? "erc1155-token-list-bit-vector"
+          : "erc721-token-list-bit-vector";
+      }
+    }
+    {
+      const builder = new Builders.TokenList.PackedList(this.chainId);
+      if (builder.isValid(this)) {
+        return this.params.nftAmount
+          ? "erc1155-token-list-packed-list"
+          : "erc721-token-list-packed-list";
+      }
+    }
+
+    throw new Error(
+      "Could not detect order kind (order might have unsupported params/calldata)"
+    );
+  }
+}
+
+const EIP712_DOMAIN = (chainId: number) => ({
+  name: "ElementEx",
+  version: "1.0.0",
+  chainId,
+  verifyingContract: Addresses.Exchange[chainId],
+});
+    
+const NFT_BUY_ORDER_EIP712_TYPES = {
+  Fee: [
+    { name: "recipient", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "feeData", type: "bytes" },
+  ],
+  Property: [
+    { name: "propertyValidator", type: "address" },
+    { name: "propertyData", type: "bytes" },
+  ],
+  NFTBuyOrder: [
+    { type: "address", name: "maker" }, 
+    { type: "address", name: "taker" }, 
+    { type: "uint256", name: "expiry" }, 
+    { type: "uint256", name: "nonce" }, 
+    { type: "address",  name: "erc20Token" }, 
+    { type: "uint256", name: "erc20TokenAmount" }, 
+    { type: "Fee[]", name: "fees" }, 
+    { type: "address", name: "nft" },
+    { type: "uint256", name: "nftId" }, 
+    { type: "Property[]",  name: "nftProperties" },
+    { type: "uint256", name: "hashNonce" }
+  ]
+}
+
+const NFT_SELL_ORDER_EIP712_TYPES = {
+  NFTSellOrder: [
+    { type: "address", name: "maker" }, 
+    { type: "address", name: "taker" }, 
+    { type: "uint256", name: "expiry" }, 
+    { type: "uint256",  name: "nonce" }, 
+    { type: "address",  name: "erc20Token" }, 
+    { type: "uint256", name: "erc20TokenAmount"}, 
+    { type: "Fee[]",   name: "fees"  }, 
+    { type: "address", name: "nft" }, 
+    { type: "uint256",  name: "nftId" }, 
+    { type: "uint256", name: "hashNonce" }
+  ],
+  Fee: [
+    { name: "recipient", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "feeData", type: "bytes" },
+  ]
+};
+
+const ERC1155_BUY_ORDER_EIP712_TYPES = {
+  ERC1155BuyOrder: [
+    { name: "maker", type: "address" },
+    { name: "taker", type: "address" },
+    { name: "expiry", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "erc20Token", type: "address" },
+    { name: "erc20TokenAmount", type: "uint256" },
+    { name: "fees", type: "Fee[]" },
+    { name: "erc1155Token", type: "address" },
+    { name: "erc1155TokenId", type: "uint256" },
+    { name: "erc1155TokenProperties", type: "Property[]" },
+    { name: "erc1155TokenAmount", type: "uint128" }, 
+    { type: "uint256", name: "hashNonce" },
+  ],
+  Fee: [
+    { name: "recipient", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "feeData", type: "bytes" },
+  ],
+  Property: [
+    { name: "propertyValidator", type: "address" },
+    { name: "propertyData", type: "bytes" },
+  ],
+};
+
+const ERC1155_SELL_ORDER_EIP712_TYPES = {
+  ERC1155SellOrder: [
+    { name: "maker", type: "address" },
+    { name: "taker", type: "address" },
+    { name: "expiry", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "erc20Token", type: "address" },
+    { name: "erc20TokenAmount", type: "uint256" },
+    { name: "fees", type: "Fee[]" },
+    { name: "erc1155Token", type: "address" },
+    { name: "erc1155TokenId", type: "uint256" },
+    { name: "erc1155TokenAmount", type: "uint128" },
+    { name: "hashNonce", type: "uint256",},
+  ],
+  Fee: [
+    { name: "recipient", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "feeData", type: "bytes" },
+  ]
+};
+
+const toRawErc721Order = (order: Order): any => ({
+  ...order.params,
+  erc721Token: order.params.nft,
+  erc721TokenId: order.params.nftId,
+  erc721TokenProperties: order.params.nftProperties,
+});
+
+const toRawErc1155Order = (order: Order): any => ({
+  ...order.params,
+  erc1155Token: order.params.nft,
+  erc1155TokenId: order.params.nftId,
+  erc1155TokenProperties: order.params.nftProperties,
+  erc1155TokenAmount: order.params.nftAmount,
+});
+
+const normalize = (order: Types.BaseOrder): Types.BaseOrder => {
+  // Perform some normalization operations on the order:
+  // - convert bignumbers to strings where needed
+  // - convert strings to numbers where needed
+  // - lowercase all strings
+
+  return {
+    kind: order.kind,
+    direction: order.direction,
+    maker: lc(order.maker),
+    taker: lc(order.taker),
+    expiry: n(order.expiry),
+    nonce: s(order.nonce),
+    erc20Token: lc(order.erc20Token),
+    erc20TokenAmount: s(order.erc20TokenAmount),
+    fees: order.fees.map(({ recipient, amount, feeData }) => ({
+      recipient: lc(recipient),
+      amount: s(amount),
+      feeData: lc(feeData),
+    })),
+    nft: lc(order.nft),
+    nftId: s(order.nftId),
+    nftProperties: order.nftProperties.map(
+      ({ propertyValidator, propertyData }) => ({
+        propertyValidator: lc(propertyValidator),
+        propertyData: lc(propertyData),
+      })
+    ),
+    nftAmount: order.nftAmount ? s(order.nftAmount) : undefined,
+    signatureType: order.signatureType ?? 0,
+    v: order.v ?? 0,
+    r: order.r ?? HashZero,
+    s: order.s ?? HashZero,
+  };
+};

--- a/packages/sdk/src/element/types.ts
+++ b/packages/sdk/src/element/types.ts
@@ -1,0 +1,49 @@
+export type OrderKind =
+  | "erc721-single-token"
+  | "erc1155-single-token"
+  | "erc721-contract-wide"
+  | "erc1155-contract-wide"
+  | "erc721-token-range"
+  | "erc1155-token-range"
+  | "erc721-token-list-bit-vector"
+  | "erc1155-token-list-bit-vector"
+  | "erc721-token-list-packed-list"
+  | "erc1155-token-list-packed-list";
+
+export enum TradeDirection {
+  SELL,
+  BUY,
+}
+
+export type BaseOrder = {
+  kind?: OrderKind;
+  direction: TradeDirection;
+  maker: string;
+  taker: string;
+  expiry: number;
+  nonce: string;
+  erc20Token: string;
+  erc20TokenAmount: string;
+  fees: {
+    recipient: string;
+    amount: string;
+    feeData: string;
+  }[];
+  nft: string;
+  nftId: string;
+  nftProperties: {
+    propertyValidator: string;
+    propertyData: string;
+  }[];
+  nftAmount?: string;
+  signatureType?: number;
+  v?: number;
+  r?: string;
+  s?: string;
+};
+
+export type MatchParams = {
+  nftId?: string;
+  nftAmount?: string;
+  unwrapNativeToken?: boolean;
+};

--- a/packages/sdk/src/router/types.ts
+++ b/packages/sdk/src/router/types.ts
@@ -10,6 +10,7 @@ export enum ExchangeKind {
   SUDOSWAP,
   ZORA,
   UNIVERSE,
+  ELEMENT,
 }
 
 export type GenericOrder =
@@ -48,6 +49,10 @@ export type GenericOrder =
   | {
       kind: "universe";
       order: Sdk.Universe.Order;
+    }
+  | {
+      kind: "element";
+      order: Sdk.Element.Order;
     };
 
 export type ListingFillDetails = {


### PR DESCRIPTION
# Element 

## Difference

### DirectTransfer
`revert with onERC721Received not implementation`

### getERC721OrderStatus / getERC1155OrderInfo

- getERC721SellOrderStatus
- getERC721BuyOrderStatus
- getERC1155SellOrderInfo
- getERC1155BuyOrderInfo

### EIP712Types: ERC721Order / ERC1155Order
```solidity

struct NFTSellOrder {
    address maker;
    address taker;
    uint256 expiry;
    uint256 nonce;
    IERC20 erc20Token;
    uint256 erc20TokenAmount;
    Fee[] fees;
    address nft;
    uint256 nftId;
}

uint256 private constant _NFT_SELL_ORDER_TYPE_HASH = 0xed676c7f3e8232a311454799b1cf26e75b4abc90c9bf06c9f7e8e79fcc7fe14d;
uint256 private constant _NFT_SELL_ORDER_TYPE_HASH = 0xed676c7f3e8232a311454799b1cf26e75b4abc90c9bf06c9f7e8e79fcc7fe14d;

// The type hash for buy orders, which is:
// keccak256(abi.encodePacked(
//    "NFTBuyOrder(",
//        "address maker,",
//        "address taker,",
//        "uint256 expiry,",
//        "uint256 nonce,",
//        "address erc20Token,",
//        "uint256 erc20TokenAmount,",
//        "Fee[] fees,",
//        "address nft,",
//        "uint256 nftId,",
//        "Property[] nftProperties,",
//        "uint256 hashNonce",
//    ")",
//    "Fee(",
//        "address recipient,",
//        "uint256 amount,",
//        "bytes feeData",
//    ")",
//    "Property(",
//        "address propertyValidator,",
//        "bytes propertyData",
//    ")"
// ))

struct NFTBuyOrder {
    address maker;
    address taker;
    uint256 expiry;
    uint256 nonce;
    IERC20 erc20Token;
    uint256 erc20TokenAmount;
    Fee[] fees;
    address nft;
    uint256 nftId;
    Property[] nftProperties;
}

struct ERC1155SellOrder {
    address maker;
    address taker;
    uint256 expiry;
    uint256 nonce;
    IERC20 erc20Token;
    uint256 erc20TokenAmount;
    Fee[] fees;
    address erc1155Token;
    uint256 erc1155TokenId;
    // End of fields shared with NFTOrder
    uint128 erc1155TokenAmount;
}

struct ERC1155BuyOrder {
    address maker;
    address taker;
    uint256 expiry;
    uint256 nonce;
    IERC20 erc20Token;
    uint256 erc20TokenAmount;
    Fee[] fees;
    address erc1155Token;
    uint256 erc1155TokenId;
    Property[] erc1155TokenProperties;
    // End of fields shared with NFTOrder
    uint128 erc1155TokenAmount;
}
```

### getHashNonce
``` typescript
public async sign(signer: TypedDataSigner, provider: Provider) {
    const [types, value] = this.getEip712TypesAndValue();
    const exchange = new Contract(
      Addresses.Exchange[this.chainId],
      ExchangeAbi as any,
      provider
    );

    const hashNonce = await exchange.getHashNonce((signer as VoidSigner).address);
    // add hashNonce
    value.hashNonce = hashNonce;

    const { v, r, s } = splitSignature(
      await signer._signTypedData(EIP712_DOMAIN(this.chainId), types, value)
    );

```


### LibSignature

```solidity
// Element
enum SignatureType {
    EIP712,
    PRESIGNED
}

// ZeroEx-v4
enum SignatureType {
    ILLEGAL,
    INVALID,
    EIP712,
    ETHSIGN,
    PRESIGNED
}
```

### buyERC721 / buyERC1155

```solidity
// Element
function buyERC721(
        LibNFTOrder.ERC721Order memory sellOrder,
        LibSignature.Signature memory signature,
        bytes memory callbackData
)
 // ZeroEx-v4
function buyERC721(
    LibNFTOrder.NFTSellOrder memory sellOrder, 
   LibSignature.Signature memory signature
)

```