### PR TITLE
Infinity order params sig

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reservoir0x/sdk",
-  "version": "0.0.275",
+  "version": "0.0.276",
   "description": "Reservoir Protocol SDK",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/sdk/src/infinity/order-params.ts
+++ b/packages/sdk/src/infinity/order-params.ts
@@ -383,6 +383,7 @@ export const normalize = (
     complication: lc(input.complication),
     extraParams: input.extraParams,
     currency: lc(input.currency),
+    signature: input.signature,
   };
 };
 


### PR DESCRIPTION
Fixes a bug causing the signature to get omitted if an `InternalOrder` or `SignedOrder` are passed to normalize