### PR TITLE
Rarible Router Module

### DIFF
--- a/packages/contracts/contracts/interfaces/IRarible.sol
+++ b/packages/contracts/contracts/interfaces/IRarible.sol
@@ -6,8 +6,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 interface IRarible {
     struct AssetType {
-        IERC165 collection;
-        uint tokenId;
         bytes4 assetClass;
         bytes data;
     }
@@ -19,9 +17,9 @@ interface IRarible {
 
     struct Order {
         address maker;
-        Asset make;
+        Asset makeAsset;
         address taker;
-        Asset take;
+        Asset takeAsset;
         uint salt;
         uint start;
         uint end;
@@ -36,7 +34,9 @@ interface IRarible {
 
     function matchOrders(
         Order calldata orderLeft,
-        Order calldata orderRight
+        bytes calldata signatureLeft,
+        Order calldata orderRight,
+        bytes calldata signatureRight
     ) external payable;
 }
 

--- a/packages/contracts/contracts/interfaces/IRarible.sol
+++ b/packages/contracts/contracts/interfaces/IRarible.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IRarible {
+    struct AssetType {
+        bytes4 assetClass;
+        bytes data;
+    }
+
+    struct Asset {
+        AssetType assetType;
+        uint value;
+    }
+
+    struct Order {
+        address maker;
+        Asset makeAsset;
+        address taker;
+        Asset takeAsset;
+        uint salt;
+        uint start;
+        uint end;
+        bytes4 dataType;
+        bytes data;
+    }
+
+    struct NftData {
+        uint tokenId;
+        IERC165 collection;
+    }
+
+    struct Purchase {
+        address sellOrderMaker;
+        uint256 sellOrderNftAmount;
+        bytes4 nftAssetClass;
+        NftData nftData;
+        uint256 sellOrderPaymentAmount;
+        IERC20 paymentToken;
+        uint256 sellOrderSalt;
+        uint sellOrderStart;
+        uint sellOrderEnd;
+        bytes4 sellOrderDataType;
+        bytes sellOrderData;
+        bytes sellOrderSignature;
+
+        uint256 buyOrderPaymentAmount;
+        uint256 buyOrderNftAmount;
+        bytes buyOrderData;
+    }
+
+    /*All accept bid parameters need for create buyOrder and sellOrder*/
+    struct AcceptBid {
+        address bidMaker;
+        uint256 bidNftAmount;
+        bytes4 nftAssetClass;
+        NftData nftData;
+        uint256 bidPaymentAmount;
+        IERC20 paymentToken;
+        uint256 bidSalt;
+        uint bidStart;
+        uint bidEnd;
+        bytes4 bidDataType;
+        bytes bidData;
+        bytes bidSignature;
+
+        uint256 sellOrderPaymentAmount;
+        uint256 sellOrderNftAmount;
+        bytes sellOrderData;
+    }
+
+    function directPurchase(
+        Purchase calldata direct
+    ) external payable;
+
+    function directAcceptBid(
+        AcceptBid calldata takerBid
+    ) external payable;
+}
+
+interface IRaribleTransferManager {
+    function TRANSFER_MANAGER() external view returns (address);
+}

--- a/packages/contracts/contracts/interfaces/IRarible.sol
+++ b/packages/contracts/contracts/interfaces/IRarible.sol
@@ -6,20 +6,22 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 interface IRarible {
     struct AssetType {
+        IERC165 collection;
+        uint tokenId;
         bytes4 assetClass;
         bytes data;
     }
 
     struct Asset {
         AssetType assetType;
-        uint value;
+        uint256 value;
     }
 
     struct Order {
         address maker;
-        Asset makeAsset;
+        Asset make;
         address taker;
-        Asset takeAsset;
+        Asset take;
         uint salt;
         uint start;
         uint end;
@@ -32,51 +34,9 @@ interface IRarible {
         IERC165 collection;
     }
 
-    struct Purchase {
-        address sellOrderMaker;
-        uint256 sellOrderNftAmount;
-        bytes4 nftAssetClass;
-        NftData nftData;
-        uint256 sellOrderPaymentAmount;
-        IERC20 paymentToken;
-        uint256 sellOrderSalt;
-        uint sellOrderStart;
-        uint sellOrderEnd;
-        bytes4 sellOrderDataType;
-        bytes sellOrderData;
-        bytes sellOrderSignature;
-
-        uint256 buyOrderPaymentAmount;
-        uint256 buyOrderNftAmount;
-        bytes buyOrderData;
-    }
-
-    /*All accept bid parameters need for create buyOrder and sellOrder*/
-    struct AcceptBid {
-        address bidMaker;
-        uint256 bidNftAmount;
-        bytes4 nftAssetClass;
-        NftData nftData;
-        uint256 bidPaymentAmount;
-        IERC20 paymentToken;
-        uint256 bidSalt;
-        uint bidStart;
-        uint bidEnd;
-        bytes4 bidDataType;
-        bytes bidData;
-        bytes bidSignature;
-
-        uint256 sellOrderPaymentAmount;
-        uint256 sellOrderNftAmount;
-        bytes sellOrderData;
-    }
-
-    function directPurchase(
-        Purchase calldata direct
-    ) external payable;
-
-    function directAcceptBid(
-        AcceptBid calldata takerBid
+    function matchOrders(
+        Order calldata orderLeft,
+        Order calldata orderRight
     ) external payable;
 }
 

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {BaseExchangeModule} from "./BaseExchangeModule.sol";
+import {BaseModule} from "../BaseModule.sol";
+import {IRarible} from "../../../interfaces/IRarible.sol";
+
+// Notes:
+// - supports filling listings (both ERC721/ERC1155 but only ETH-denominated)
+// - supports filling offers (both ERC721/ERC1155)
+
+contract RaribleModule is BaseExchangeModule {
+    using SafeERC20 for IERC20;
+
+    // --- Fields ---
+
+    IRarible public constant EXCHANGE =
+        IRarible(0x9757F2d2b135150BBeb65308D4a91804107cd8D6);
+
+    address public constant TRANSFER_MANAGER =          
+        0x4feE7B061C97C9c496b01DbcE9CDb10c02f0a0Be;
+
+    bytes4 public constant ERC721_INTERFACE = 0x80ac58cd;
+    bytes4 public constant ERC1155_INTERFACE = 0xd9b67a26;
+
+    // --- Constructor ---
+
+    constructor(address owner, address router)
+        BaseModule(owner)
+        BaseExchangeModule(router)
+    {}
+
+    // --- Single ETH listing ---
+
+    function acceptETHListing(
+        IRarible.Purchase calldata direct,
+        ETHListingParams calldata params,
+        Fee[] calldata fees
+    )
+        external
+        payable
+        nonReentrant
+        refundETHLeftover(params.refundTo)
+        chargeETHFees(fees, params.amount)
+    {
+        // Execute fill
+        _buy(
+            direct,
+            params.fillTo,
+            params.revertIfIncomplete,
+            params.amount
+        );
+    }
+
+    // --- Multiple ETH listings ---
+
+    function acceptETHListings(
+        IRarible.Purchase[] calldata directs,
+        ETHListingParams calldata params,
+        Fee[] calldata fees
+    )
+        external
+        payable
+        nonReentrant
+        refundETHLeftover(params.refundTo)
+        chargeETHFees(fees, params.amount)
+    {
+        for (uint256 i = 0; i < directs.length; ) {
+            // Use `memory` to avoid `Stack too deep` errors
+            IRarible.Purchase calldata direct = directs[i];
+
+            // Execute fill
+            _buy(
+                direct,
+                params.fillTo,
+                params.revertIfIncomplete,
+                direct.sellOrderPaymentAmount
+            );
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // --- [ERC721] Single offer ---
+
+    function acceptERC721Offer(
+        IRarible.AcceptBid calldata direct,
+        OfferParams calldata params,
+        Fee[] calldata fees
+    ) external nonReentrant {
+        IERC721 collection = IERC721(address(direct.nftData.collection));
+
+        // Approve the transfer manager if needed
+        _approveERC721IfNeeded(collection, TRANSFER_MANAGER);
+
+        // Execute the fill
+        _sell(
+            direct,
+            params.fillTo,
+            params.revertIfIncomplete,
+            fees
+        );
+
+        // Refund any ERC721 leftover
+        _sendAllERC721(params.refundTo, collection, direct.nftData.tokenId);
+    }
+
+    // --- [ERC1155] Single offer ---
+
+    function acceptERC1155Offer(
+        IRarible.AcceptBid calldata direct,
+        OfferParams calldata params,
+        Fee[] calldata fees
+    ) external nonReentrant {
+        IERC1155 collection = IERC1155(address(direct.nftData.collection));
+
+        // Approve the transfer manager if needed
+        _approveERC1155IfNeeded(collection, TRANSFER_MANAGER);
+
+        // Execute the fill
+        _sell(
+            direct,
+            params.fillTo,
+            params.revertIfIncomplete,
+            fees
+        );
+
+        // Refund any ERC1155 leftover
+        _sendAllERC1155(params.refundTo, collection, direct.nftData.tokenId);
+    }
+
+    // --- ERC721 / ERC1155 hooks ---
+
+    // Single token offer acceptance can be done approval-less by using the
+    // standard `safeTransferFrom` method together with specifying data for
+    // further contract calls. An example:
+    // `safeTransferFrom(
+    //      0xWALLET,
+    //      0xMODULE,
+    //      TOKEN_ID,
+    //      0xABI_ENCODED_ROUTER_EXECUTION_CALLDATA_FOR_OFFER_ACCEPTANCE
+    // )`
+
+    function onERC721Received(
+        address, // operator,
+        address, // from
+        uint256, // tokenId,
+        bytes calldata data
+    ) external returns (bytes4) {
+        if (data.length > 0) {
+            _makeCall(router, data, 0);
+        }
+
+        return this.onERC721Received.selector;
+    }
+
+    function onERC1155Received(
+        address, // operator
+        address, // from
+        uint256, // tokenId
+        uint256, // amount
+        bytes calldata data
+    ) external returns (bytes4) {
+        if (data.length > 0) {
+            _makeCall(router, data, 0);
+        }
+
+        return this.onERC1155Received.selector;
+    }
+
+    // --- Internal ---
+
+    function _buy(
+        IRarible.Purchase calldata direct,
+        address receiver,
+        bool revertIfIncomplete,
+        uint256 value
+    ) internal {
+        // Execute the fill
+        try
+            EXCHANGE.directPurchase{value: value}(direct)
+        {
+            IERC165 collection = direct.nftData.collection;
+
+            // Forward any token to the specified receiver
+            bool isERC721 = collection.supportsInterface(ERC721_INTERFACE);
+            if (isERC721) {
+                IERC721(address(collection)).safeTransferFrom(
+                    address(this),
+                    receiver,
+                    direct.nftData.tokenId
+                );
+            } else {
+                bool isERC1155 = collection.supportsInterface(
+                    ERC1155_INTERFACE
+                );
+                if (isERC1155) {
+                    IERC1155(address(collection)).safeTransferFrom(
+                        address(this),
+                        receiver,
+                        direct.nftData.tokenId,
+                        direct.sellOrderPaymentAmount,
+                        ""
+                    );
+                }
+            }
+        } catch {
+            // Revert if specified
+            if (revertIfIncomplete) {
+                revert UnsuccessfulFill();
+            }
+        }
+    }
+
+        function _sell(
+        IRarible.AcceptBid calldata direct,
+        address receiver,
+        bool revertIfIncomplete,
+        Fee[] calldata fees
+    ) internal {
+        // Execute the fill
+        try EXCHANGE.directAcceptBid(direct) {
+            // Pay fees
+            uint256 feesLength = fees.length;
+            for (uint256 i; i < feesLength; ) {
+                Fee memory fee = fees[i];
+                _sendERC20(fee.recipient, fee.amount, direct.paymentToken);
+
+                unchecked {
+                    ++i;
+                }
+            }
+
+            // Forward any left payment to the specified receiver
+            _sendAllERC20(receiver, direct.paymentToken);
+        } catch {
+            // Revert if specified
+            if (revertIfIncomplete) {
+                revert UnsuccessfulFill();
+            }
+        }
+    }
+}

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -221,7 +221,7 @@ contract RaribleModule is BaseExchangeModule {
             EXCHANGE.matchOrders{value: value}(orderLeft, signatureLeft, orderRight, signatureRight)
         {
             (address token, uint tokenId) = abi.decode(orderLeft.makeAsset.assetType.data, (address, uint256));
-            IERC165 collection = IERC165(address(token));
+            IERC165 collection = IERC165(token);
 
             // Forward any token to the specified receiver
             bool isERC721 = collection.supportsInterface(ERC721_INTERFACE);
@@ -265,7 +265,7 @@ contract RaribleModule is BaseExchangeModule {
             for (uint256 i; i < feesLength; ) {
                 Fee memory fee = fees[i];
                 
-                _sendERC20(fee.recipient, fee.amount, IERC20(address(token)));
+                _sendERC20(fee.recipient, fee.amount, IERC20(token));
 
                 unchecked {
                     ++i;
@@ -273,7 +273,7 @@ contract RaribleModule is BaseExchangeModule {
             }
 
             // Forward any left payment to the specified receiver
-            _sendAllERC20(receiver, IERC20(address(token)));
+            _sendAllERC20(receiver, IERC20(token));
         } catch {
             // Revert if specified
             if (revertIfIncomplete) {

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -112,7 +112,8 @@ contract RaribleModule is BaseExchangeModule {
         OfferParams calldata params,
         Fee[] calldata fees
     ) external nonReentrant {
-        (address token, uint tokenId) = abi.decode(orderLeft.makeAsset.assetType.data, (address, uint256));
+        (address token, uint tokenId) = abi.decode(orderLeft.takeAsset.assetType.data, (address, uint256));
+
         IERC721 collection = IERC721(address(token));
 
         // Approve the transfer manager if needed
@@ -143,7 +144,7 @@ contract RaribleModule is BaseExchangeModule {
         OfferParams calldata params,
         Fee[] calldata fees
     ) external nonReentrant {
-        (address token, uint tokenId) = abi.decode(orderLeft.makeAsset.assetType.data, (address, uint256));
+        (address token, uint tokenId) = abi.decode(orderLeft.takeAsset.assetType.data, (address, uint256));
 
         IERC1155 collection = IERC1155(address(token));
 

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -242,7 +242,7 @@ contract RaribleModule is BaseExchangeModule {
                     address(this),
                     receiver,
                     tokenId,
-                    orderLeft.takeAsset.value,
+                    orderLeft.makeAsset.value,
                     ""
                 );
             }

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -10,6 +10,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {BaseExchangeModule} from "./BaseExchangeModule.sol";
 import {BaseModule} from "../BaseModule.sol";
 import {IRarible} from "../../../interfaces/IRarible.sol";
+import "hardhat/console.sol";
 
 // Notes:
 // - supports filling listings (both ERC721/ERC1155 but only ETH-denominated)
@@ -52,6 +53,7 @@ contract RaribleModule is BaseExchangeModule {
         refundETHLeftover(params.refundTo)
         chargeETHFees(fees, params.amount)
     {
+        console.log("asd");
         // Execute fill
         _buy(
             orderLeft,
@@ -80,6 +82,8 @@ contract RaribleModule is BaseExchangeModule {
         refundETHLeftover(params.refundTo)
         chargeETHFees(fees, params.amount)
     {
+        console.log("asd2");
+        
         for (uint256 i = 0; i < ordersLeft.length; ) {
             IRarible.Order calldata orderLeft = ordersLeft[i];
             IRarible.Order calldata orderRight = ordersRight[i];
@@ -94,6 +98,7 @@ contract RaribleModule is BaseExchangeModule {
                 params.revertIfIncomplete,
                 orderLeft.makeAsset.value
             );
+            console.log("asd3");
 
             unchecked {
                 ++i;
@@ -214,13 +219,15 @@ contract RaribleModule is BaseExchangeModule {
         bool revertIfIncomplete,
         uint256 value
     ) internal {
+        console.log("asd5");
         // Execute the fill
         try
             EXCHANGE.matchOrders{value: value}(orderLeft, signatureLeft, orderRight, signatureRight)
         {
+            console.log("asd4");
             (address token, uint tokenId) = abi.decode(orderLeft.makeAsset.assetType.data, (address, uint256));
-
             IERC165 collection = IERC165(address(token));
+            console.log(token);
 
             // Forward any token to the specified receiver
             bool isERC721 = collection.supportsInterface(ERC721_INTERFACE);
@@ -240,11 +247,14 @@ contract RaribleModule is BaseExchangeModule {
                 );
             }
         } catch {
+            console.log("asd6");
             // Revert if specified
             if (revertIfIncomplete) {
+                console.log("asd7");
                 revert UnsuccessfulFill();
             }
         }
+        console.log("asd8");
     }
 
     function _sell(
@@ -259,7 +269,7 @@ contract RaribleModule is BaseExchangeModule {
         // Execute the fill
         try EXCHANGE.matchOrders(orderLeft, signatureLeft, orderRight, signatureRight) {
             // Pay fees
-            (address token, uint tokenId) = abi.decode(orderLeft.makeAsset.assetType.data, (address, uint256));
+            address token = abi.decode(orderLeft.makeAsset.assetType.data, (address));
             uint256 feesLength = fees.length;
             for (uint256 i; i < feesLength; ) {
                 Fee memory fee = fees[i];

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -231,18 +231,13 @@ contract RaribleModule is BaseExchangeModule {
                     tokenId
                 );
             } else {
-                bool isERC1155 = collection.supportsInterface(
-                    ERC1155_INTERFACE
+                IERC1155(address(collection)).safeTransferFrom(
+                    address(this),
+                    receiver,
+                    tokenId,
+                    orderLeft.takeAsset.value,
+                    ""
                 );
-                if (isERC1155) {
-                    IERC1155(address(collection)).safeTransferFrom(
-                        address(this),
-                        receiver,
-                        tokenId,
-                        orderLeft.takeAsset.value,
-                        ""
-                    );
-                }
             }
         } catch {
             // Revert if specified

--- a/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/RaribleModule.sol
@@ -53,7 +53,6 @@ contract RaribleModule is BaseExchangeModule {
         refundETHLeftover(params.refundTo)
         chargeETHFees(fees, params.amount)
     {
-        console.log("asd");
         // Execute fill
         _buy(
             orderLeft,
@@ -81,9 +80,7 @@ contract RaribleModule is BaseExchangeModule {
         nonReentrant
         refundETHLeftover(params.refundTo)
         chargeETHFees(fees, params.amount)
-    {
-        console.log("asd2");
-        
+    {        
         for (uint256 i = 0; i < ordersLeft.length; ) {
             IRarible.Order calldata orderLeft = ordersLeft[i];
             IRarible.Order calldata orderRight = ordersRight[i];
@@ -96,9 +93,8 @@ contract RaribleModule is BaseExchangeModule {
                 signatureRight,
                 params.fillTo,
                 params.revertIfIncomplete,
-                orderLeft.makeAsset.value
+                orderLeft.takeAsset.value
             );
-            console.log("asd3");
 
             unchecked {
                 ++i;
@@ -219,15 +215,12 @@ contract RaribleModule is BaseExchangeModule {
         bool revertIfIncomplete,
         uint256 value
     ) internal {
-        console.log("asd5");
         // Execute the fill
         try
             EXCHANGE.matchOrders{value: value}(orderLeft, signatureLeft, orderRight, signatureRight)
         {
-            console.log("asd4");
             (address token, uint tokenId) = abi.decode(orderLeft.makeAsset.assetType.data, (address, uint256));
             IERC165 collection = IERC165(address(token));
-            console.log(token);
 
             // Forward any token to the specified receiver
             bool isERC721 = collection.supportsInterface(ERC721_INTERFACE);
@@ -247,14 +240,11 @@ contract RaribleModule is BaseExchangeModule {
                 );
             }
         } catch {
-            console.log("asd6");
             // Revert if specified
             if (revertIfIncomplete) {
-                console.log("asd7");
                 revert UnsuccessfulFill();
             }
         }
-        console.log("asd8");
     }
 
     function _sell(

--- a/packages/contracts/test/router/v6/helpers/rarible.ts
+++ b/packages/contracts/test/router/v6/helpers/rarible.ts
@@ -1,0 +1,172 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+import { Contract } from "@ethersproject/contracts";
+import * as Sdk from "@reservoir0x/sdk/src";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { ethers } from "hardhat";
+
+import { getChainId, getCurrentTimestamp } from "../../../utils";
+
+// --- Listings ---
+
+export interface IPart {
+  account: string;
+  value: string;
+}
+
+export enum ORDER_DATA_TYPES {
+  DEFAULT_DATA_TYPE = "0xffffffff",
+  LEGACY = "LEGACY",
+  V1 = "V1",
+  API_V1 = "ETH_RARIBLE_V1",
+  V2 = "V2",
+  API_V2 = "ETH_RARIBLE_V2",
+  V3_SELL = "V3_SELL",
+  API_V3_SELL = "ETH_RARIBLE_V2_DATA_V3_SELL",
+  V3_BUY = "V3_BUY",
+  API_V3_BUY = "ETH_RARIBLE_V2_DATA_V3_BUY",
+}
+
+export enum ORDER_TYPES {
+  V1 = "RARIBLE_V1",
+  V2 = "RARIBLE_V2",
+}
+
+export type OrderKind = "single-token" | "contract-wide";
+
+export type RaribleListing = {
+  orderType: ORDER_TYPES;
+  maker: SignerWithAddress;
+  side: "buy" | "sell";
+  tokenKind: "erc721" | "erc1155" | "erc721_lazy" | "erc1155_lazy";
+  contract: Contract;
+  tokenId: string;
+  tokenAmount?: number;
+  price: string;
+  paymentToken: string;
+  salt?: BigNumberish;
+  startTime: number;
+  endTime: number;
+  dataType: ORDER_DATA_TYPES;
+
+  // Lazy mint options
+  uri?: string;
+  supply?: string;
+  creators?: IPart[];
+  royalties?: IPart[];
+  signatures?: string[];
+  // Fields below should be based on the data type of the order
+  // They are optional currently and we assume they're passed correctly
+  // TODO: Validation should be added to ensure correct all params exist and are passed correctly
+  originFees?: IPart[];
+  payouts?: IPart[];
+  originFeeFirst?: IPart;
+  originFeeSecond?: IPart;
+  marketplaceMarker?: string;
+  fee?: number;
+  maxFeesBasePoint?: number;
+  order?: Sdk.Rarible.Order;
+};
+
+export interface IV3OrderSellData {
+  "@type"?: string;
+  dataType: ORDER_DATA_TYPES;
+  payouts: IPart;
+  originFeeFirst: IPart;
+  originFeeSecond: IPart;
+  maxFeesBasePoint: number;
+  marketplaceMarker: string;
+}
+
+export interface IV3OrderBuyData {
+  "@type"?: string;
+  dataType: ORDER_DATA_TYPES;
+  payouts: IPart;
+  originFeeFirst: IPart;
+  originFeeSecond: IPart;
+  marketplaceMarker: string;
+}
+
+export type LocalAssetType = {
+  assetClass: string;
+  contract: Contract;
+  tokenId: string;
+  uri?: string;
+  supply?: string;
+  creators?: IPart[];
+  royalties?: IPart[];
+  signatures?: string[];
+};
+
+export type LocalAsset = {
+  // Comes from API
+  type?: any;
+  assetType: LocalAssetType;
+  value: string;
+};
+
+export const setupRaribleListings = async (listings: RaribleListing[]) => {
+  const chainId = getChainId();
+  const exchange = new Sdk.LooksRare.Exchange(chainId);
+
+  for (const listing of listings) {
+    const { maker, tokenId, tokenKind, contract } = listing;
+
+    // Approve the exchange contract
+    await contract.connect(maker).mint(tokenId);
+    await contract
+      .connect(maker)
+      .setApprovalForAll(Sdk.Rarible.Addresses.NFTTransferProxy[chainId], true);
+
+    // Build and sign the order
+    const builder = new Sdk.Rarible.Builders.SingleToken(chainId);
+    const order = builder.build({
+      orderType: ORDER_TYPES.V2,
+      maker: maker.address,
+      side: "sell",
+      tokenKind: tokenKind,
+      contract: contract.address,
+      price: listing.price,
+      dataType: listing.dataType,
+      tokenId,
+      paymentToken: listing.paymentToken,
+      startTime: await getCurrentTimestamp(ethers.provider),
+      endTime: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+    await order.sign(maker);
+  }
+};
+
+// --- Offers ---
+
+export const setupRaribleOffers = async (offers: RaribleListing[]) => {
+  const chainId = getChainId();
+  const exchange = new Sdk.Rarible.Exchange(chainId);
+
+  for (const offer of offers) {
+    const { maker, tokenId, tokenKind, contract, price } = offer;
+
+    const weth = new Sdk.Common.Helpers.Weth(ethers.provider, chainId);
+    await weth.deposit(maker, price);
+    await weth.approve(
+      maker,
+      Sdk.Rarible.Addresses.ERC20TransferProxy[chainId]
+    );
+
+    // Build and sign the order
+    const builder = new Sdk.Rarible.Builders.SingleToken(chainId);
+    const order = builder.build({
+      orderType: ORDER_TYPES.V2,
+      maker: maker.address,
+      side: offer.side,
+      tokenKind: tokenKind,
+      contract: contract.address,
+      price: price,
+      dataType: offer.dataType,
+      tokenId,
+      paymentToken: offer.paymentToken,
+      startTime: await getCurrentTimestamp(ethers.provider),
+      endTime: (await getCurrentTimestamp(ethers.provider)) + 60,
+    });
+    await order.sign(maker);
+  }
+};

--- a/packages/contracts/test/router/v6/helpers/rarible.ts
+++ b/packages/contracts/test/router/v6/helpers/rarible.ts
@@ -109,7 +109,7 @@ export const setupRaribleListings = async (listings: RaribleListing[]) => {
   const exchange = new Sdk.LooksRare.Exchange(chainId);
 
   for (const listing of listings) {
-    const { maker, tokenId, tokenKind, contract } = listing;
+    const { maker, tokenId, tokenKind, contract, payouts } = listing;
 
     // Approve the exchange contract
     await contract.connect(maker).mint(tokenId);
@@ -131,7 +131,10 @@ export const setupRaribleListings = async (listings: RaribleListing[]) => {
       paymentToken: listing.paymentToken,
       startTime: await getCurrentTimestamp(ethers.provider),
       endTime: (await getCurrentTimestamp(ethers.provider)) + 60,
+      payouts,
     });
+
+    listing.order = order;
     await order.sign(maker);
   }
 };

--- a/packages/contracts/test/router/v6/helpers/rarible.ts
+++ b/packages/contracts/test/router/v6/helpers/rarible.ts
@@ -123,7 +123,10 @@ export const setupRaribleListings = async (listings: RaribleListing[]) => {
       ],
     });
 
+    await order.checkValidity();
     await order.sign(maker);
+    await order.checkSignature();
+    await order.checkFillability(ethers.provider);
 
     listing.order = order;
 

--- a/packages/contracts/test/router/v6/rarible/listings.test.ts
+++ b/packages/contracts/test/router/v6/rarible/listings.test.ts
@@ -5,6 +5,7 @@ import * as Sdk from "@reservoir0x/sdk/src";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { expect } from "chai";
 import { ethers } from "hardhat";
+import * as Rarible from "@reservoir0x/sdk/src/rarible";
 
 import { ExecutionInfo } from "../helpers/router";
 import { RaribleListing, setupRaribleListings } from "../helpers/rarible";
@@ -125,6 +126,8 @@ describe("[ReservoirV6_0_0] Rarible listings", () => {
         .reduce((a, b) => bn(a).add(b), bn(0))
     );
 
+    const exchange = new Rarible.Exchange(chainId);
+
     const matchOrder = listings[0].order!.buildMatching(
       raribleModule.address,
       listings[0].order!.params
@@ -233,6 +236,13 @@ describe("[ReservoirV6_0_0] Rarible listings", () => {
       Sdk.Common.Addresses.Weth[chainId]
     );
 
+    // await exchange.fillOrder(carol, listings[0].order!, {
+    //   tokenId: listings[0].nft.id.toString(),
+    //   assetClass: listings[0].nft.kind!.toUpperCase() as any,
+    // });
+
+    console.log("test");
+
     // Execute
 
     await router.connect(carol).execute(executions, {
@@ -253,7 +263,7 @@ describe("[ReservoirV6_0_0] Rarible listings", () => {
     // Checks
 
     // Alice got the payment
-    expect(wethBalancesAfter.alice.sub(wethBalancesBefore.alice)).to.eq(
+    expect(ethBalancesAfter.alice.sub(ethBalancesAfter.alice)).to.eq(
       listings
         .filter(
           ({ maker, isCancelled }) =>
@@ -268,7 +278,7 @@ describe("[ReservoirV6_0_0] Rarible listings", () => {
         .reduce((a, b) => bn(a).add(b), bn(0))
     );
     // Bob got the payment
-    expect(wethBalancesAfter.bob.sub(wethBalancesBefore.bob)).to.eq(
+    expect(ethBalancesAfter.bob.sub(ethBalancesAfter.bob)).to.eq(
       listings
         .filter(
           ({ maker, isCancelled }) =>

--- a/packages/contracts/test/router/v6/rarible/listings.test.ts
+++ b/packages/contracts/test/router/v6/rarible/listings.test.ts
@@ -1,0 +1,326 @@
+import { BigNumber } from "@ethersproject/bignumber";
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Sdk from "@reservoir0x/sdk/src";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { ExecutionInfo } from "../helpers/router";
+import {
+  ORDER_DATA_TYPES,
+  ORDER_TYPES,
+  RaribleListing,
+  setupRaribleListings,
+} from "../helpers/rarible";
+import {
+  bn,
+  getChainId,
+  getRandomBoolean,
+  getRandomFloat,
+  getRandomInteger,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+import { getCurrentTimestamp } from "@reservoir0x/sdk/src/utils";
+import { constants } from "ethers";
+
+describe("[ReservoirV6_0_0] Rarible listings", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let david: SignerWithAddress;
+  let emilio: SignerWithAddress;
+
+  let erc1155: Contract;
+  let erc721: Contract;
+  let router: Contract;
+  let raribleModule: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob, carol, david, emilio] = await ethers.getSigners();
+
+    ({ erc721, erc1155 } = await setupNFTs(deployer));
+
+    router = (await ethers
+      .getContractFactory("ReservoirV6_0_0", deployer)
+      .then((factory) => factory.deploy())) as any;
+    raribleModule = (await ethers
+      .getContractFactory("RaribleModule", deployer)
+      .then((factory) =>
+        factory.deploy(router.address, router.address)
+      )) as any;
+  });
+
+  const getBalances = async (token: string) => {
+    if (token === Sdk.Common.Addresses.Eth[chainId]) {
+      return {
+        alice: await ethers.provider.getBalance(alice.address),
+        bob: await ethers.provider.getBalance(bob.address),
+        carol: await ethers.provider.getBalance(carol.address),
+        david: await ethers.provider.getBalance(david.address),
+        emilio: await ethers.provider.getBalance(emilio.address),
+        router: await ethers.provider.getBalance(router.address),
+        raribleModule: await ethers.provider.getBalance(raribleModule.address),
+      };
+    } else {
+      const contract = new Sdk.Common.Helpers.Erc20(ethers.provider, token);
+      return {
+        alice: await contract.getBalance(alice.address),
+        bob: await contract.getBalance(bob.address),
+        carol: await contract.getBalance(carol.address),
+        david: await contract.getBalance(david.address),
+        emilio: await contract.getBalance(emilio.address),
+        router: await contract.getBalance(router.address),
+        raribleModule: await contract.getBalance(raribleModule.address),
+      };
+    }
+  };
+
+  afterEach(reset);
+
+  const testAcceptListings = async (
+    // Whether to include fees on top
+    chargeFees: boolean,
+    // Whether to revert or not in case of any failures
+    revertIfIncomplete: boolean,
+    // Whether to cancel some orders in order to trigger partial filling
+    partial: boolean,
+    // Number of listings to fill
+    listingsCount: number
+  ) => {
+    // Setup
+
+    // Makers: Alice and Bob
+    // Taker: Carol
+    // Fee recipient: Emilio
+
+    const listings: RaribleListing[] = [];
+    const feesOnTop: BigNumber[] = [];
+    for (let i = 0; i < listingsCount; i++) {
+      const random = getRandomBoolean();
+      listings.push({
+        maker: random ? alice : bob,
+        orderType: ORDER_TYPES.V2,
+        side: "sell",
+        tokenKind: random ? "erc721" : "erc1155",
+        contract: random ? erc721 : erc1155,
+        price: parseEther(getRandomFloat(0.0001, 2).toFixed(6)).toString(),
+        dataType: ORDER_DATA_TYPES.V3_SELL,
+        tokenId: getRandomInteger(1, 10000).toString(),
+        paymentToken: constants.AddressZero,
+        startTime: getCurrentTimestamp(),
+        endTime: getCurrentTimestamp() + 60,
+      });
+      if (chargeFees) {
+        feesOnTop.push(parseEther(getRandomFloat(0.0001, 0.1).toFixed(6)));
+      }
+    }
+    await setupRaribleListings(listings);
+
+    // Prepare executions
+
+    const totalPrice = bn(
+      listings.map(({ price }) => price).reduce((a, b) => bn(a).add(b), bn(0))
+    );
+    const executions: ExecutionInfo[] = [
+      // 1. Fill listings
+      listingsCount > 1
+        ? {
+            module: raribleModule.address,
+            data: raribleModule.interface.encodeFunctionData(
+              "acceptETHListings",
+              [
+                listings.map((listing) =>
+                  listing.order!.buildMatching(raribleModule.address)
+                ),
+                listings.map((listing) => listing.order!.params),
+                {
+                  fillTo: carol.address,
+                  refundTo: carol.address,
+                  revertIfIncomplete,
+                  amount: totalPrice,
+                },
+                [
+                  ...feesOnTop.map((amount) => ({
+                    recipient: emilio.address,
+                    amount,
+                  })),
+                ],
+              ]
+            ),
+            value: totalPrice.add(
+              // Anything on top should be refunded
+              feesOnTop
+                .reduce((a, b) => bn(a).add(b), bn(0))
+                .add(parseEther("0.1"))
+            ),
+          }
+        : {
+            module: raribleModule.address,
+            data: raribleModule.interface.encodeFunctionData(
+              "acceptETHListing",
+              [
+                listings[0].order!.buildMatching(raribleModule.address),
+                listings[0].order!.params,
+                {
+                  fillTo: carol.address,
+                  refundTo: carol.address,
+                  revertIfIncomplete,
+                  amount: totalPrice,
+                },
+                chargeFees
+                  ? feesOnTop.map((amount) => ({
+                      recipient: emilio.address,
+                      amount,
+                    }))
+                  : [],
+              ]
+            ),
+            value: totalPrice.add(
+              // Anything on top should be refunded
+              feesOnTop
+                .reduce((a, b) => bn(a).add(b), bn(0))
+                .add(parseEther("0.1"))
+            ),
+          },
+    ];
+
+    // Checks
+
+    // If the `revertIfIncomplete` option is enabled and we have any
+    // orders that are not fillable, the whole transaction should be
+    // reverted
+    if (partial && revertIfIncomplete) {
+      await expect(
+        router.connect(carol).execute(executions, {
+          value: executions
+            .map(({ value }) => value)
+            .reduce((a, b) => bn(a).add(b), bn(0)),
+        })
+      ).to.be.revertedWith(
+        "reverted with custom error 'UnsuccessfulExecution()'"
+      );
+
+      return;
+    }
+
+    // Fetch pre-state
+
+    const ethBalancesBefore = await getBalances(
+      Sdk.Common.Addresses.Eth[chainId]
+    );
+    const wethBalancesBefore = await getBalances(
+      Sdk.Common.Addresses.Weth[chainId]
+    );
+
+    // Execute
+
+    await router.connect(carol).execute(executions, {
+      value: executions
+        .map(({ value }) => value)
+        .reduce((a, b) => bn(a).add(b), bn(0)),
+    });
+
+    // Fetch post-state
+
+    const ethBalancesAfter = await getBalances(
+      Sdk.Common.Addresses.Eth[chainId]
+    );
+    const wethBalancesAfter = await getBalances(
+      Sdk.Common.Addresses.Weth[chainId]
+    );
+
+    // Checks
+
+    // Alice got the payment
+    expect(wethBalancesAfter.alice.sub(wethBalancesBefore.alice)).to.eq(
+      listings
+        .filter(({ maker }) => maker.address === alice.address)
+        .map(({ price }) =>
+          bn(price).sub(
+            // Take into consideration the protocol fee
+            bn(price).mul(150).div(10000)
+          )
+        )
+        .reduce((a, b) => bn(a).add(b), bn(0))
+    );
+    // Bob got the payment
+    expect(wethBalancesAfter.bob.sub(wethBalancesBefore.bob)).to.eq(
+      listings
+        .filter(({ maker }) => maker.address === bob.address)
+        .map(({ price }) =>
+          bn(price).sub(
+            // Take into consideration the protocol fee
+            bn(price).mul(150).div(10000)
+          )
+        )
+        .reduce((a, b) => bn(a).add(b), bn(0))
+    );
+
+    // Emilio got the fee payments
+    if (chargeFees) {
+      // Fees are charged per execution, and since we have a single execution
+      // here, we will have a single fee payment at the end adjusted over the
+      // amount that was actually paid (eg. prices of filled orders)
+      const actualPaid = listings
+        .map(({ price }) => price)
+        .reduce((a, b) => bn(a).add(b), bn(0));
+      expect(ethBalancesAfter.emilio.sub(ethBalancesBefore.emilio)).to.eq(
+        listings
+          .map((_, i) => feesOnTop[i].mul(actualPaid).div(totalPrice))
+          .reduce((a, b) => bn(a).add(b), bn(0))
+      );
+    }
+
+    // Carol got the NFTs from all filled orders
+    for (let i = 0; i < listings.length; i++) {
+      // const nft = listings[i].nft;
+
+      if (listings[i].tokenKind === "erc721") {
+        expect(await listings[i].contract.ownerOf(listings[i].tokenId)).to.eq(
+          listings[i].maker.address
+        );
+      } else {
+        expect(
+          await listings[i].contract.balanceOf(
+            listings[i].maker.address,
+            listings[i].tokenId
+          )
+        ).to.eq(1);
+      }
+    }
+
+    // Router is stateless
+    expect(wethBalancesAfter.router).to.eq(0);
+    expect(wethBalancesAfter.raribleModule).to.eq(0);
+    expect(ethBalancesAfter.router).to.eq(0);
+    expect(ethBalancesAfter.raribleModule).to.eq(0);
+  };
+
+  for (let multiple of [false, true]) {
+    for (let partial of [false, true]) {
+      for (let chargeFees of [false, true]) {
+        for (let revertIfIncomplete of [false, true]) {
+          it(
+            "[eth]" +
+              `${multiple ? "[multiple-orders]" : "[single-order]"}` +
+              `${partial ? "[partial]" : "[full]"}` +
+              `${chargeFees ? "[fees]" : "[no-fees]"}` +
+              `${revertIfIncomplete ? "[reverts]" : "[skip-reverts]"}`,
+            async () =>
+              testAcceptListings(
+                chargeFees,
+                revertIfIncomplete,
+                partial,
+                multiple ? getRandomInteger(2, 6) : 1
+              )
+          );
+        }
+      }
+    }
+  }
+});

--- a/packages/contracts/test/router/v6/rarible/offers.test.ts
+++ b/packages/contracts/test/router/v6/rarible/offers.test.ts
@@ -1,0 +1,333 @@
+import { BigNumber } from "@ethersproject/bignumber";
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import * as Sdk from "@reservoir0x/sdk/src";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { ExecutionInfo } from "../helpers/router";
+import {
+  SeaportERC721Approval,
+  setupSeaportERC721Approvals,
+} from "../helpers/seaport";
+import {
+  ORDER_DATA_TYPES,
+  ORDER_TYPES,
+  RaribleListing,
+  setupRaribleOffers,
+} from "../helpers/rarible";
+import {
+  bn,
+  getChainId,
+  getRandomBoolean,
+  getRandomFloat,
+  getRandomInteger,
+  reset,
+  setupNFTs,
+} from "../../../utils";
+import { getCurrentTimestamp } from "@reservoir0x/sdk/src/utils";
+
+describe("[ReservoirV6_0_0] Rarible offers", () => {
+  const chainId = getChainId();
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let david: SignerWithAddress;
+  let emilio: SignerWithAddress;
+
+  let erc721: Contract;
+  let router: Contract;
+  let seaportApprovalOrderZone: Contract;
+  let seaportModule: Contract;
+  let raribleModule: Contract;
+
+  beforeEach(async () => {
+    [deployer, alice, bob, carol, david, emilio] = await ethers.getSigners();
+
+    ({ erc721 } = await setupNFTs(deployer));
+
+    router = (await ethers
+      .getContractFactory("ReservoirV6_0_0", deployer)
+      .then((factory) => factory.deploy())) as any;
+    seaportApprovalOrderZone = (await ethers
+      .getContractFactory("SeaportApprovalOrderZone", deployer)
+      .then((factory) => factory.deploy())) as any;
+    seaportModule = (await ethers
+      .getContractFactory("SeaportModule", deployer)
+      .then((factory) =>
+        factory.deploy(router.address, router.address)
+      )) as any;
+    raribleModule = (await ethers
+      .getContractFactory("RaribleModule", deployer)
+      .then((factory) =>
+        factory.deploy(router.address, router.address)
+      )) as any;
+  });
+
+  const getBalances = async (token: string) => {
+    if (token === Sdk.Common.Addresses.Eth[chainId]) {
+      return {
+        alice: await ethers.provider.getBalance(alice.address),
+        bob: await ethers.provider.getBalance(bob.address),
+        carol: await ethers.provider.getBalance(carol.address),
+        david: await ethers.provider.getBalance(david.address),
+        emilio: await ethers.provider.getBalance(emilio.address),
+        router: await ethers.provider.getBalance(router.address),
+        seaportModule: await ethers.provider.getBalance(seaportModule.address),
+        raribleModule: await ethers.provider.getBalance(raribleModule.address),
+      };
+    } else {
+      const contract = new Sdk.Common.Helpers.Erc20(ethers.provider, token);
+      return {
+        alice: await contract.getBalance(alice.address),
+        bob: await contract.getBalance(bob.address),
+        carol: await contract.getBalance(carol.address),
+        david: await contract.getBalance(david.address),
+        emilio: await contract.getBalance(emilio.address),
+        router: await contract.getBalance(router.address),
+        seaportModule: await contract.getBalance(seaportModule.address),
+        raribleModule: await contract.getBalance(raribleModule.address),
+      };
+    }
+  };
+
+  afterEach(reset);
+
+  const testAcceptOffers = async (
+    // Whether to charge fees on the received amount
+    chargeFees: boolean,
+    // Whether to revert or not in case of any failures
+    revertIfIncomplete: boolean,
+    // Whether to cancel some orders in order to trigger partial filling
+    partial: boolean,
+    // Number of offers to fill
+    offersCount: number
+  ) => {
+    // Setup
+
+    // Makers: Alice and Bob
+    // Taker: Carol
+
+    const wethAddress = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+    const offers: RaribleListing[] = [];
+    const fees: BigNumber[][] = [];
+    for (let i = 0; i < offersCount; i++) {
+      offers.push({
+        orderType: ORDER_TYPES.V2,
+        side: "buy",
+        paymentToken: wethAddress,
+        dataType: ORDER_DATA_TYPES.V3_BUY,
+        maker: getRandomBoolean() ? alice : bob,
+        tokenKind: "erc721",
+        contract: erc721,
+        tokenId: getRandomInteger(1, 10000).toString(),
+        price: parseEther(getRandomFloat(0.2, 2).toFixed(6)).toString(),
+        startTime: getCurrentTimestamp(),
+        endTime: getCurrentTimestamp() + 60,
+      });
+      if (chargeFees) {
+        fees.push([parseEther(getRandomFloat(0.0001, 0.1).toFixed(6))]);
+      } else {
+        fees.push([]);
+      }
+    }
+    await setupRaribleOffers(offers);
+
+    // In order to avoid giving NFT approvals to the router (remember,
+    // the router is supposed to be stateless), we do create multiple
+    // Seaport orders (we can also have a single aggregated order for
+    // bundling everything together) which give the NFTs to the router
+    // (eg. offer = NFT and consideration = NFT - with the router as a
+    // private recipient). This way, the NFT approvals will be made on
+    // the Seaport conduit and the router stays stateless.
+
+    const approvals: SeaportERC721Approval[] = offers.map((offer) => ({
+      giver: carol,
+      filler: seaportModule.address,
+      receiver: raribleModule.address,
+      nft: {
+        kind: "erc721",
+        contract: offer.contract,
+        id: bn(offer.tokenId).toNumber(),
+        amount: offer.tokenAmount,
+      },
+      zone: seaportApprovalOrderZone.address,
+    }));
+    await setupSeaportERC721Approvals(approvals);
+
+    // Prepare executions
+
+    const executions: ExecutionInfo[] = [
+      // 1. Fill the approval orders, so that we avoid giving approval to the router
+      {
+        module: seaportModule.address,
+        data: seaportModule.interface.encodeFunctionData("matchOrders", [
+          [
+            ...approvals
+              .map(({ orders }) => [
+                // Regular order
+                {
+                  parameters: {
+                    ...orders![0].params,
+                    totalOriginalConsiderationItems:
+                      orders![0].params.consideration.length,
+                  },
+                  signature: orders![0].params.signature,
+                },
+                // Mirror order
+                {
+                  parameters: {
+                    ...orders![1].params,
+                    totalOriginalConsiderationItems:
+                      orders![1].params.consideration.length,
+                  },
+                  signature: "0x",
+                },
+              ])
+              .flat(),
+          ],
+          // For each regular order, match the single offer item to the single consideration item
+          [
+            ...approvals.map((_, i) => ({
+              offerComponents: [
+                {
+                  orderIndex: i * 2,
+                  itemIndex: 0,
+                },
+              ],
+              considerationComponents: [
+                {
+                  orderIndex: i * 2,
+                  itemIndex: 0,
+                },
+              ],
+            })),
+          ],
+        ]),
+        value: 0,
+      },
+      // 2. Fill offers with the received NFTs
+      ...offers.map((offer, i) => ({
+        module: raribleModule.address,
+        data: raribleModule.interface.encodeFunctionData("acceptERC721Offer", [
+          offer.order!.buildMatching(raribleModule.address),
+          offer.order!.params,
+          {
+            fillTo: carol.address,
+            refundTo: carol.address,
+            revertIfIncomplete,
+          },
+          [
+            ...fees[i].map((amount) => ({
+              recipient: emilio.address,
+              amount,
+            })),
+          ],
+        ]),
+        value: 0,
+      })),
+    ];
+
+    // Checks
+
+    // If the `revertIfIncomplete` option is enabled and we have any
+    // orders that are not fillable, the whole transaction should be
+    // reverted
+    if (partial && revertIfIncomplete) {
+      await expect(
+        router.connect(carol).execute(executions, {
+          value: executions
+            .map(({ value }) => value)
+            .reduce((a, b) => bn(a).add(b), bn(0)),
+        })
+      ).to.be.revertedWith(
+        "reverted with custom error 'UnsuccessfulExecution()'"
+      );
+
+      return;
+    }
+
+    // Fetch pre-state
+
+    const balancesBefore = await getBalances(
+      Sdk.Common.Addresses.Weth[chainId]
+    );
+
+    // Execute
+
+    await router.connect(carol).execute(executions, {
+      value: executions
+        .map(({ value }) => value)
+        .reduce((a, b) => bn(a).add(b), bn(0)),
+    });
+
+    // Fetch post-state
+
+    const balancesAfter = await getBalances(Sdk.Common.Addresses.Weth[chainId]);
+
+    // Checks
+
+    // Carol got the payment
+    expect(balancesAfter.carol.sub(balancesBefore.carol)).to.eq(
+      offers
+        .map((offer, i) =>
+          bn(offer.price)
+            .sub(
+              // Take into consideration the protocol fee
+              bn(offer.price).mul(150).div(10000)
+            )
+            .sub(fees[i].reduce((a, b) => bn(a).add(b), bn(0)))
+        )
+        .reduce((a, b) => bn(a).add(b), bn(0))
+    );
+
+    // Emilio got the fee payments
+    if (chargeFees) {
+      expect(balancesAfter.emilio.sub(balancesBefore.emilio)).to.eq(
+        offers
+          .map((_, i) => fees[i])
+          .map((executionFees) =>
+            executionFees.reduce((a, b) => bn(a).add(b), bn(0))
+          )
+          .reduce((a, b) => bn(a).add(b), bn(0))
+      );
+    }
+
+    // Alice and Bob got the NFTs of the filled orders
+    for (const { contract, tokenId } of offers) {
+      expect(await contract.ownerOf(tokenId)).to.eq(carol.address);
+    }
+
+    // Router is stateless
+    expect(balancesAfter.router).to.eq(0);
+    expect(balancesAfter.seaportModule).to.eq(0);
+    expect(balancesAfter.raribleModule).to.eq(0);
+  };
+
+  // Test various combinations for filling offers
+
+  for (let multiple of [false, true]) {
+    for (let partial of [false, true]) {
+      for (let chargeFees of [false, true]) {
+        for (let revertIfIncomplete of [false, true]) {
+          it(
+            `${multiple ? "[multiple-orders]" : "[single-order]"}` +
+              `${partial ? "[partial]" : "[full]"}` +
+              `${chargeFees ? "[fees]" : "[no-fees]"}` +
+              `${revertIfIncomplete ? "[reverts]" : "[skip-reverts]"}`,
+            async () =>
+              testAcceptOffers(
+                chargeFees,
+                revertIfIncomplete,
+                partial,
+                multiple ? getRandomInteger(2, 4) : 1
+              )
+          );
+        }
+      }
+    }
+  }
+});

--- a/packages/sdk/src/rarible/builders/single-token/index.ts
+++ b/packages/sdk/src/rarible/builders/single-token/index.ts
@@ -95,11 +95,9 @@ export class SingleTokenBuilder extends BaseBuilder {
           ? {
               assetClass: AssetClass.ERC20,
               contract: lc(params.paymentToken),
-              collection: lc(params.paymentToken),
             }
           : {
               assetClass: AssetClass.ETH,
-              collection: constants.AddressZero,
             }),
       },
       value: params.price,
@@ -125,8 +123,6 @@ export class SingleTokenBuilder extends BaseBuilder {
     taker: string,
     data: { amount?: string }
   ) {
-    order.make.assetType.collection = order.make.assetType.contract;
-    order.take.assetType.collection = constants.AddressZero;
     const rightOrder = {
       type: order.type,
       maker: lc(taker),
@@ -160,17 +156,9 @@ export class SingleTokenBuilder extends BaseBuilder {
 
     // for erc1155 we need to take the value from request (the amount parameter)
     if (AssetClass.ERC1155 == order.make.assetType.assetClass) {
-      rightOrder.take.value = Math.floor(Number(data.amount)).toString();
+      rightOrder.take.value = Math.floor(Number(data.amount || "1")).toString();
     }
 
-    if (AssetClass.ERC1155 == order.take.assetType.assetClass) {
-      const oldValue = rightOrder.make.value;
-
-      rightOrder.make.value = Math.floor(Number(data.amount)).toString();
-      rightOrder.take.value = BigNumber.from(rightOrder.take.value).div(
-        oldValue - rightOrder.make.value || "1"
-      );
-    }
     return rightOrder;
   }
 }

--- a/packages/sdk/src/rarible/builders/single-token/index.ts
+++ b/packages/sdk/src/rarible/builders/single-token/index.ts
@@ -1,7 +1,7 @@
 import { BaseBuilder, BaseOrderInfo } from "../base";
 import { Order } from "../../order";
 import * as Types from "../../types";
-import { lc, n, s } from "../../../utils";
+import { bn, lc, n, s } from "../../../utils";
 import { BigNumber, constants } from "ethers/lib/ethers";
 import { AssetClass } from "../../types";
 import { ORDER_DATA_TYPES } from "../../constants";
@@ -95,9 +95,11 @@ export class SingleTokenBuilder extends BaseBuilder {
           ? {
               assetClass: AssetClass.ERC20,
               contract: lc(params.paymentToken),
+              collection: lc(params.paymentToken),
             }
           : {
               assetClass: AssetClass.ETH,
+              collection: constants.AddressZero,
             }),
       },
       value: params.price,
@@ -123,6 +125,8 @@ export class SingleTokenBuilder extends BaseBuilder {
     taker: string,
     data: { amount?: string }
   ) {
+    order.make.assetType.collection = order.make.assetType.contract;
+    order.take.assetType.collection = constants.AddressZero;
     const rightOrder = {
       type: order.type,
       maker: lc(taker),

--- a/packages/sdk/src/rarible/types.ts
+++ b/packages/sdk/src/rarible/types.ts
@@ -211,10 +211,10 @@ export interface BaseBuildParams {
   // They are optional currently and we assume they're passed correctly
   // TODO: Validation should be added to ensure correct all params exist and are passed correctly
   originFees?: IPart[];
-  payouts?: IPart[]; //
-  originFeeFirst?: IPart; //
-  originFeeSecond?: IPart; //
-  marketplaceMarker?: string; //
+  payouts?: IPart[];
+  originFeeFirst?: IPart;
+  originFeeSecond?: IPart;
+  marketplaceMarker?: string;
   fee?: number;
-  maxFeesBasePoint?: number; //
+  maxFeesBasePoint?: number;
 }

--- a/packages/sdk/src/rarible/types.ts
+++ b/packages/sdk/src/rarible/types.ts
@@ -57,7 +57,6 @@ export type LocalAssetType = {
   creators?: IPart[];
   royalties?: IPart[];
   signatures?: string[];
-  collection?: string;
 };
 
 export type LocalAsset = {
@@ -91,6 +90,7 @@ export type Order = {
   side?: string;
   createdAt?: string;
   endedAt?: string;
+  amount?: number;
 };
 
 export type Purchase = {

--- a/packages/sdk/src/rarible/types.ts
+++ b/packages/sdk/src/rarible/types.ts
@@ -57,6 +57,7 @@ export type LocalAssetType = {
   creators?: IPart[];
   royalties?: IPart[];
   signatures?: string[];
+  collection?: string;
 };
 
 export type LocalAsset = {

--- a/packages/sdk/src/rarible/types.ts
+++ b/packages/sdk/src/rarible/types.ts
@@ -210,10 +210,10 @@ export interface BaseBuildParams {
   // They are optional currently and we assume they're passed correctly
   // TODO: Validation should be added to ensure correct all params exist and are passed correctly
   originFees?: IPart[];
-  payouts?: IPart[];
-  originFeeFirst?: IPart;
-  originFeeSecond?: IPart;
-  marketplaceMarker?: string;
+  payouts?: IPart[]; //
+  originFeeFirst?: IPart; //
+  originFeeSecond?: IPart; //
+  marketplaceMarker?: string; //
   fee?: number;
-  maxFeesBasePoint?: number;
+  maxFeesBasePoint?: number; //
 }

--- a/packages/sdk/src/router/v6/abis/RaribleModule.json
+++ b/packages/sdk/src/router/v6/abis/RaribleModule.json
@@ -1,0 +1,1457 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidParams",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsuccessfulCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsuccessfulFill",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsuccessfulPayment",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongParams",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "CallExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1155_INTERFACE",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ERC721_INTERFACE",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "EXCHANGE",
+    "outputs": [
+      {
+        "internalType": "contract IRarible",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TRANSFER_MANAGER",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order",
+        "name": "orderLeft",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order",
+        "name": "orderRight",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.OfferParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptERC1155Offer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order",
+        "name": "orderLeft",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order",
+        "name": "orderRight",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.OfferParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptERC721Offer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order",
+        "name": "orderLeft",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order",
+        "name": "orderRight",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.ETHListingParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptETHListing",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order[]",
+        "name": "ordersLeft",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "make",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "taker",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "contract IERC165",
+                    "name": "collection",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes4",
+                    "name": "assetClass",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ],
+                "internalType": "struct IRarible.AssetType",
+                "name": "assetType",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IRarible.Asset",
+            "name": "take",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "dataType",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRarible.Order[]",
+        "name": "ordersRight",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.ETHListingParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptETHListings",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "targets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "makeCalls",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk/src/router/v6/abis/RaribleModule.json
+++ b/packages/sdk/src/router/v6/abis/RaribleModule.json
@@ -155,16 +155,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -186,7 +176,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -199,16 +189,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -230,7 +210,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -264,6 +244,11 @@
         "type": "tuple"
       },
       {
+        "internalType": "bytes",
+        "name": "signatureLeft",
+        "type": "bytes"
+      },
+      {
         "components": [
           {
             "internalType": "address",
@@ -274,16 +259,6 @@
             "components": [
               {
                 "components": [
-                  {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
                   {
                     "internalType": "bytes4",
                     "name": "assetClass",
@@ -306,7 +281,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -319,16 +294,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -350,7 +315,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -382,6 +347,11 @@
         "internalType": "struct IRarible.Order",
         "name": "orderRight",
         "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signatureRight",
+        "type": "bytes"
       },
       {
         "components": [
@@ -442,16 +412,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -473,7 +433,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -486,16 +446,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -517,7 +467,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -551,6 +501,11 @@
         "type": "tuple"
       },
       {
+        "internalType": "bytes",
+        "name": "signatureLeft",
+        "type": "bytes"
+      },
+      {
         "components": [
           {
             "internalType": "address",
@@ -561,16 +516,6 @@
             "components": [
               {
                 "components": [
-                  {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
                   {
                     "internalType": "bytes4",
                     "name": "assetClass",
@@ -593,7 +538,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -606,16 +551,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -637,7 +572,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -669,6 +604,11 @@
         "internalType": "struct IRarible.Order",
         "name": "orderRight",
         "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signatureRight",
+        "type": "bytes"
       },
       {
         "components": [
@@ -729,16 +669,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -760,7 +690,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -773,16 +703,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -804,7 +724,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -838,6 +758,11 @@
         "type": "tuple"
       },
       {
+        "internalType": "bytes",
+        "name": "signatureLeft",
+        "type": "bytes"
+      },
+      {
         "components": [
           {
             "internalType": "address",
@@ -848,16 +773,6 @@
             "components": [
               {
                 "components": [
-                  {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
                   {
                     "internalType": "bytes4",
                     "name": "assetClass",
@@ -880,7 +795,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -893,16 +808,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -924,7 +829,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -956,6 +861,11 @@
         "internalType": "struct IRarible.Order",
         "name": "orderRight",
         "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signatureRight",
+        "type": "bytes"
       },
       {
         "components": [
@@ -1021,16 +931,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -1052,7 +952,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -1065,16 +965,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -1096,7 +986,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -1130,6 +1020,11 @@
         "type": "tuple[]"
       },
       {
+        "internalType": "bytes[]",
+        "name": "signaturesLeft",
+        "type": "bytes[]"
+      },
+      {
         "components": [
           {
             "internalType": "address",
@@ -1140,16 +1035,6 @@
             "components": [
               {
                 "components": [
-                  {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
                   {
                     "internalType": "bytes4",
                     "name": "assetClass",
@@ -1172,7 +1057,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "make",
+            "name": "makeAsset",
             "type": "tuple"
           },
           {
@@ -1185,16 +1070,6 @@
               {
                 "components": [
                   {
-                    "internalType": "contract IERC165",
-                    "name": "collection",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "tokenId",
-                    "type": "uint256"
-                  },
-                  {
                     "internalType": "bytes4",
                     "name": "assetClass",
                     "type": "bytes4"
@@ -1216,7 +1091,7 @@
               }
             ],
             "internalType": "struct IRarible.Asset",
-            "name": "take",
+            "name": "takeAsset",
             "type": "tuple"
           },
           {
@@ -1248,6 +1123,11 @@
         "internalType": "struct IRarible.Order[]",
         "name": "ordersRight",
         "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signatureRight",
+        "type": "bytes"
       },
       {
         "components": [

--- a/packages/sdk/src/router/v6/addresses.ts
+++ b/packages/sdk/src/router/v6/addresses.ts
@@ -68,3 +68,8 @@ export const ElementModule: ChainIdToAddress = {
 export const NFTXModule: ChainIdToAddress = {
   [Network.Ethereum]: "0x27eb35119dda39df73db6681019edc4c16311acc",
 };
+
+export const RaribleModule: ChainIdToAddress = {
+  [Network.Ethereum]: "0x9757f2d2b135150bbeb65308d4a91804107cd8d6",
+  [Network.EthereumGoerli]: "0x02afbd43cad367fcb71305a2dfb9a3928218f0c1",
+};

--- a/packages/sdk/src/router/v6/addresses.ts
+++ b/packages/sdk/src/router/v6/addresses.ts
@@ -70,6 +70,6 @@ export const NFTXModule: ChainIdToAddress = {
 };
 
 export const RaribleModule: ChainIdToAddress = {
-  [Network.Ethereum]: "0x9757f2d2b135150bbeb65308d4a91804107cd8d6",
-  [Network.EthereumGoerli]: "0x02afbd43cad367fcb71305a2dfb9a3928218f0c1",
+  [Network.Ethereum]: "",
+  [Network.EthereumGoerli]: "",
 };

--- a/packages/sdk/src/router/v6/router.ts
+++ b/packages/sdk/src/router/v6/router.ts
@@ -1466,8 +1466,6 @@ export class Router {
         .map(({ amount }) => bn(amount))
         .reduce((a, b) => a.add(b), bn(0));
 
-      const order = orders[0];
-
       executions.push({
         module,
         data:
@@ -1510,7 +1508,7 @@ export class Router {
       });
 
       // Mark the listings as successfully handled
-      for (const { originalIndex } of looksRareDetails) {
+      for (const { originalIndex } of raribleDetails) {
         success[originalIndex] = true;
       }
     }


### PR DESCRIPTION
Rarible router module works with erc721 and erc1155. Handles offers and multiple listings.

Note: Rarible listings need to be encoded before being sent to the module to match their contract logic.